### PR TITLE
 feat: major v4 overhaul — Laravel 13, Pest, expanded API coverage

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,0 @@
-preset: laravel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Run tests
 composer test
 # or directly
-./vendor/bin/phpunit
+./vendor/bin/pest
 
 # Format code (Laravel Pint)
 ./vendor/bin/pint
 
 # Run a single test file
-./vendor/bin/phpunit tests/Path/To/TestFile.php
+./vendor/bin/pest tests/Path/To/TestFile.php
 
 # Run a single test method
-./vendor/bin/phpunit --filter testMethodName
+./vendor/bin/pest --filter testMethodName
 ```
 
 Code style is enforced by StyleCI (preset: laravel). Run Pint locally before committing.
@@ -41,16 +41,25 @@ Functionality is organised into traits mixed into `TOPDesk`:
 | Trait | Domain |
 |---|---|
 | `Incidents` | Create, update, list incidents/tickets |
-| `Persons` | Person/user lookups |
-| `Assets` | Asset management |
-| `Changes` | Change management |
-| `Counts` | Statistical counts |
+| `IncidentActions` | Escalate/deescalate, time tracking, actions, attachments |
+| `IncidentLookups` | Lookup lists (priorities, urgencies, call types, SLAs, etc.) |
+| `Persons` | Person/user lookups, create, update, archive |
+| `PersonManagement` | Person and person-group CRUD |
+| `OperatorManagement` | Operator and operator-group CRUD |
 | `OperatorStats` | Operator-level statistics |
+| `Assets` | Asset management (CRUD, templates, assignments, statuses) |
+| `Branches` | Branch lookups and creation |
+| `Locations` | Location lookups and creation |
+| `Departments` | Department queries and creation |
+| `Suppliers` | Supplier lookups and contacts |
+| `Changes` | Change management queries |
+| `Counts` | Statistical counts |
+| `General` | API version, search, countries, languages |
 | `DeprecatedMethods` | Stubs that throw on use |
 
 ### Models
 
-`src/Models/BaseModel.php` is an abstract base for TOPdesk entities (`Operator`, `Person`, `OperatorGroup`, `PersonGroup`, `Asset`). It provides:
+`src/Models/BaseModel.php` is an abstract base for TOPdesk entities (`Asset`, `Branch`, `Location`, `Operator`, `OperatorGroup`, `Person`, `PersonGroup`, `Supplier`). It provides:
 
 - `find($variable, $value)` / `findById($id)` / `findFirstByVariable($variable, $value)` — query the API with 5-minute caching
 - `whereVariableEquals($field, $value)` — filtered collection lookup
@@ -62,7 +71,7 @@ Functionality is organised into traits mixed into `TOPDesk`:
 
 ### Caching
 
-Uses `fredbradley/cacher`. Default TTL is 5 minutes (`EasySeconds::minutes(5)`). Cache keys are slugified endpoint + query variable names. Most public methods accept a `bool $forgetCache` parameter to bypass or clear the cache. Set `TOPdesk_ignore_cache=true` in `.env` to disable globally.
+Uses `fredbradley/easytime` (`EasySeconds`). Default TTL is 5 minutes (`EasySeconds::minutes(5)`). Cache keys are slugified endpoint + query variable names. Most public methods accept a `bool $forgetCache` parameter to bypass or clear the cache. Set `TOPdesk_ignore_cache=true` in `.env` to disable globally.
 
 ### Configuration
 
@@ -82,6 +91,7 @@ TOPdesk_ignore_cache=false
 - `ConfigNotFound` — missing or empty config value
 - `OperatorNotFound` — operator lookup returned nothing (HTTP 404)
 - `OperatorGroupNotFound` — operator group lookup returned nothing
+- `PersonNotFound` — person lookup returned nothing (HTTP 404)
 
 ### FIQL queries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About this project
+
+`fredbradley/topdesk` is a Laravel package that wraps the TOPdesk REST API. It supports Laravel 9–13 and PHP ^8.2.
+
+## Commands
+
+```bash
+# Run tests
+composer test
+# or directly
+./vendor/bin/phpunit
+
+# Format code (Laravel Pint)
+./vendor/bin/pint
+
+# Run a single test file
+./vendor/bin/phpunit tests/Path/To/TestFile.php
+
+# Run a single test method
+./vendor/bin/phpunit --filter testMethodName
+```
+
+Code style is enforced by StyleCI (preset: laravel). Run Pint locally before committing.
+
+## Architecture
+
+### Entry points
+
+- `src/TOPDesk.php` — main class; composes all domain traits
+- `src/Facades/TOPDesk.php` — static facade alias
+- `src/TOPDeskServiceProvider.php` — registers the singleton, publishes config, and adds `Http::topdeskAuth()` macro for pre-authenticated requests
+
+### Trait-based domain split
+
+Functionality is organised into traits mixed into `TOPDesk`:
+
+| Trait | Domain |
+|---|---|
+| `Incidents` | Create, update, list incidents/tickets |
+| `Persons` | Person/user lookups |
+| `Assets` | Asset management |
+| `Changes` | Change management |
+| `Counts` | Statistical counts |
+| `OperatorStats` | Operator-level statistics |
+| `DeprecatedMethods` | Stubs that throw on use |
+
+### Models
+
+`src/Models/BaseModel.php` is an abstract base for TOPdesk entities (`Operator`, `Person`, `OperatorGroup`, `PersonGroup`, `Asset`). It provides:
+
+- `find($variable, $value)` / `findById($id)` / `findFirstByVariable($variable, $value)` — query the API with 5-minute caching
+- `whereVariableEquals($field, $value)` — filtered collection lookup
+- Properties are assigned dynamically from API JSON responses
+
+### HTTP layer
+
+`TOPDesk` wraps Laravel's `Http` facade with basic auth (configured via `TOPdesk_app_username` / `TOPdesk_app_password`). The private helpers `get()`, `post()`, `put()`, `patch()`, `delete()` all return parsed objects; 204 No Content returns an empty array.
+
+### Caching
+
+Uses `fredbradley/cacher`. Default TTL is 5 minutes (`EasySeconds::minutes(5)`). Cache keys are slugified endpoint + query variable names. Most public methods accept a `bool $forgetCache` parameter to bypass or clear the cache. Set `TOPdesk_ignore_cache=true` in `.env` to disable globally.
+
+### Configuration
+
+Published via `php artisan vendor:publish`. Environment variables:
+
+```
+TOPdesk_endpoint=
+TOPdesk_app_username=
+TOPdesk_app_password=
+TOPdesk_ignore_cache=false
+```
+
+`ConfigNotFound` is thrown during boot if any of the first three are missing.
+
+### Exceptions
+
+- `ConfigNotFound` — missing or empty config value
+- `OperatorNotFound` — operator lookup returned nothing (HTTP 404)
+- `OperatorGroupNotFound` — operator group lookup returned nothing
+
+### FIQL queries
+
+The TOPdesk API uses FIQL syntax for filtering. Pass query strings like `(field==value);(other!=value)` in the `query` key of request params.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 This is a TOPdesk API wrapper for Laravel. Using Laravel's HTTP Facade. Please check out the [Version 1 releases](https://github.com/fredbradley/topdesk/tree/v1.2.15) if you do not use Laravel, or the original package from [Innovaat](https://github.com/innovaat/topdesk-php).  
 
 ## Minimum Requirements
-- PHP 8.0 or higher
+- PHP 8.2 or higher
+- Laravel 9–13
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ TOPdesk_app_password="" # Your application password for that username.
 ## Guide
 Our TOPdesk API implementation contains the following features:
 - Simple login using application passwords.
-- Automatic retry functionality that retries requests when connection errors or status codes >= 500 occur.
- We have experienced various instabilities with the TOPdesk API, and hopefully this minimizes these shortcomings. 
-- Direct function calls for much used api endpoints (`createIncident($params)`, `getIncidentById($id)`,
-`getListOfIncidents()`, `escalateIncidentById($id)`, `deescalateIncidentById($id)`, `getListOfDepartments()`,
-`createDepartment($params)`, `getListOfBranches()`, `createBranch($params)` among others).
-- Easy syntax for all other endpoints using `$api->request($method, $uri, $json = [], $query = [])`.
+- Response caching (5-minute default TTL) to reduce API load; cache can be busted per-call or disabled globally.
+- Direct function calls for common API endpoints (`createIncident($params)`, `getIncident($number)`,
+`getListOfIncidents()`, `escalateIncident($id, $reasonId)`, `deescalateIncident($id, $reasonId)`, `getDepartments()`,
+`createDepartment($name)`, `getBranches()`, `createBranch($data)` among others).
+- Low-level HTTP helpers (`get()`, `post()`, `put()`, `patch()`, `delete()`) for endpoints not covered by named methods.
 
 
 Now your API should be ready to use:
@@ -52,15 +51,17 @@ foreach($incidents as $incident) {
 ```
 
 Many requests have been implemented as direct functions of the API. However, not all of them have been implemented.
-For manual API requests, use the `request()` function:
+For unlisted endpoints you can call the HTTP helpers directly:
 ```php
-TOPDesk::request('GET', 'api/incidents/call_types', [
-    // Optional array to be sent as JSON body (for POST/PUT requests).
-], [
-    // Optional (search) query parameters, see API documentation for supported values.
-], [
-    // Optional parameters for the Guzzle request itself.
-    // @see http://docs.guzzlephp.org/en/stable/request-options.html
+// GET with optional query parameters
+TOPDesk::get('api/incidents/call_types', [
+    // Optional key => value query parameters
+]);
+
+// POST / PUT / PATCH with a JSON body
+TOPDesk::post('api/incidents', [
+    'callerLookup' => ['id' => $callerId],
+    'briefDescription' => 'My incident',
 ]);
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,124 @@
+# Upgrade Guide: master → 4.x
+
+## Requirements
+
+| | master | 4.x |
+|---|---|---|
+| PHP | ^8.0 | ^8.2 |
+| Laravel | ~9\|~10\|~11\|~12 | ~9\|~10\|~11\|~12\|~13 |
+
+---
+
+## Removed methods
+
+### `TOPDesk::request()`
+
+This method was already marked deprecated and now throws on every call. It has been removed entirely.
+
+```php
+// before
+TOPDesk::request('GET', 'api/...', $body, $query, $options);
+
+// after — use the explicit HTTP verb methods
+TOPDesk::get('api/...', $query);
+TOPDesk::post('api/...', $body);
+TOPDesk::put('api/...', $body);
+TOPDesk::patch('api/...', $body);
+TOPDesk::delete('api/...', $body);
+```
+
+---
+
+## Changed method signatures
+
+### `OperatorStats::resolveCountsForOperatorGroup()`
+
+The second parameter was renamed from `$ignoreUsername` (singular) to `$ignoreUsernames` (plural). If you are passing this argument **by name** it will break; positional callers are unaffected.
+
+```php
+// before (named argument)
+TOPDesk::resolveCountsForOperatorGroup('I.T. Services', ignoreUsername: ['jsmith']);
+
+// after
+TOPDesk::resolveCountsForOperatorGroup('I.T. Services', ignoreUsernames: ['jsmith']);
+```
+
+### `Incidents::getOperatorByUsername()`
+
+`$forgetCache` is now declared `bool`. PHP will coerce most values silently, but strict-type callers passing non-boolean values should update.
+
+```php
+// before
+TOPDesk::getOperatorByUsername('jsmith', 1);
+
+// after
+TOPDesk::getOperatorByUsername('jsmith', true);
+```
+
+---
+
+## Changed return types
+
+The following methods previously returned a plain `array` and now return an `Illuminate\Support\Collection`. Most array operations (`count()`, `foreach`, indexed access) continue to work on Collections, but strict `array` type hints in calling code will break.
+
+| Method | Old return | New return |
+|---|---|---|
+| `Changes::allOpenChangeActivities()` | `array` | `Collection` |
+| `Changes::unassignedWaitingChangeActivities()` | `array` | `Collection` |
+| `Changes::waitingChangeActivitiesByUsername()` | `array` | `Collection` |
+| `Changes::resolvedChangeActivitiesByOperatorIdByTime()` | `array` | `Collection` |
+| `Changes::waitingChangeActivitiesByOperatorId()` | `array` | `Collection` |
+| `OperatorStats::getOperatorsByOperatorGroup()` | `array` | `Collection` |
+
+**Migration:** anywhere you type-hint `array` for these results, change to `\Illuminate\Support\Collection` or remove the type hint.
+
+---
+
+## Changed exception behaviour
+
+### `Persons::getPersonByUsername()` — exception type
+
+Now throws `FredBradley\TOPDesk\Exceptions\PersonNotFound` instead of the generic `\Exception`.
+
+```php
+// before
+try {
+    TOPDesk::getPersonByUsername('jsmith');
+} catch (\Exception $e) {
+    // caught generic Exception
+}
+
+// after — catch the specific exception (still extends \Exception, so existing
+// bare \Exception catches continue to work, but prefer the specific type)
+use FredBradley\TOPDesk\Exceptions\PersonNotFound;
+
+try {
+    TOPDesk::getPersonByUsername('jsmith');
+} catch (PersonNotFound $e) {
+    // HTTP 404-equivalent
+}
+```
+
+### `ConfigNotFound` — base class changed
+
+`ConfigNotFound` now extends `\RuntimeException` instead of `\Exception`. Both share the same ancestor, so existing `catch (\Exception $e)` blocks still catch it.
+
+---
+
+## Changed API endpoints
+
+### `Persons::getPersonById()`
+
+The internal endpoint changed from the legacy `/api/persons/id/{id}` pattern to `/api/persons/{id}` (TOPdesk v2 persons API). This is transparent to callers of the public method but affects any code that constructs URLs manually.
+
+---
+
+## Removed dependency: `fredbradley/cacher`
+
+The package no longer depends on `fredbradley/cacher`. All caching now goes through Laravel's built-in `Illuminate\Support\Facades\Cache`. If your application referenced `FredBradley\Cacher\Cacher` directly (or relied on it being present transitively), add it to your own `composer.json`.
+
+---
+
+## Test suite: PHPUnit → Pest
+
+The dev dependency has changed from `phpunit/phpunit` to `pestphp/pest`. If you extend the package's test helpers or run tests in a pipeline, update your tooling accordingly. The `composer test` script now runs `./vendor/bin/pest`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,8 +1,8 @@
-# Upgrade Guide: master → 4.x
+# Upgrade Guide: 3.x → 4.x
 
 ## Requirements
 
-| | master | 4.x |
+| | 3.x | 4.x |
 |---|---|---|
 | PHP | ^8.0 | ^8.2 |
 | Laravel | ~9\|~10\|~11\|~12 | ~9\|~10\|~11\|~12\|~13 |

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "*",
-        "laravel/pint": "*"
+        "orchestra/testbench": "^10.0",
+        "laravel/pint": "^1.0"
     },
     "scripts": {
         "test": "./vendor/bin/pest",

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,20 @@
         "TOPDesk"
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/support": "~9|~10|~11|~12",
-        "fredbradley/cacher": "^2.0",
-        "madebybob/php-number": "^1.4",
+        "php": "^8.2",
+        "illuminate/support": "~9|~10|~11|~12|~13",
         "fredbradley/easytime": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "mockery/mockery": "^1.1",
         "orchestra/testbench": "*",
         "laravel/pint": "*"
+    },
+    "scripts": {
+        "test": "./vendor/bin/pest",
+        "test:coverage": "./vendor/bin/pest --coverage"
     },
     "autoload": {
         "psr-4": {
@@ -45,6 +48,11 @@
             "aliases": {
                 "TOPDesk": "FredBradley\\TOPDesk\\Facades\\TOPDesk"
             }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
         }
     }
 }

--- a/config/topdesk.php
+++ b/config/topdesk.php
@@ -5,4 +5,5 @@ return [
     'application_username' => env('TOPdesk_app_username'),
     'application_password' => env('TOPdesk_app_password'),
     'ignore_cache' => env('TOPdesk_ignore_cache', false),
+    'cache_driver' => env('TOPdesk_cache_driver', 'file'),
 ];

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# TOPDesk Laravel Package — Documentation
+
+A Laravel wrapper for the TOPdesk REST API. Supports Laravel 9–13 and PHP 8.2+.
+
+## Contents
+
+| Document | What it covers |
+|---|---|
+| [Getting Started](getting-started.md) | Installation, configuration, basic usage |
+| [Incidents](incidents.md) | Create, update, list, actions, time, escalation, archiving, lookup lists |
+| [People](people.md) | Person lookups, create/update, person groups |
+| [Operators](operators.md) | Operator lookups, create/update, operator groups, per-operator stats |
+| [Assets](assets.md) | Asset CRUD, assignments, links, history, lookup lists |
+| [Supporting Files](supporting-files.md) | Branches, locations, departments, suppliers, countries, languages |
+| [Change Management](changes.md) | Change activities — open, resolved, per-operator |
+| [Statistics](statistics.md) | Counts and breakdowns for dashboards |
+| [Caching](caching.md) | Cache TTLs, per-call cache busting, global disable |
+| [Advanced](advanced.md) | FIQL syntax, raw HTTP access, models, error handling, testing |
+
+## Quick example
+
+```php
+use FredBradley\TOPDesk\Facades\TOPDesk;
+
+$incident = TOPDesk::createIncident([
+    'callerLookup'     => ['id' => TOPDesk::getPersonByUsername('jsmith')->id],
+    'briefDescription' => 'Laptop will not turn on',
+    'entryType'        => ['name' => 'Phone'],
+    'operatorGroup'    => ['id' => TOPDesk::getOperatorGroupId('I.T. Services')],
+]);
+
+echo $incident->number; // I-2024-00042
+```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,185 @@
+# Advanced Usage
+
+## FIQL query syntax
+
+TOPdesk uses FIQL (Feed Item Query Language) for server-side filtering on list endpoints. Pass the filter string in the `query` key:
+
+```php
+TOPDesk::getListOfIncidents([
+    'query' => '(processingStatus.name==Open);(operatorGroup.name==I.T. Services)',
+]);
+```
+
+| Operator | Meaning | Example |
+|---|---|---|
+| `==` | Equals | `status.name==Open` |
+| `!=` | Not equals | `status.name!=Closed` |
+| `=in=` | In list | `status.name=in=(Open,InProgress)` |
+| `=out=` | Not in list | `status.name=out=(Closed,Archived)` |
+| `;` | AND | `status.name==Open;operatorGroup.name==IT` |
+| `,` | OR | `status.name==Open,status.name==InProgress` |
+
+Fields available for filtering depend on the endpoint — refer to the [TOPdesk API documentation](https://developers.topdesk.com/).
+
+---
+
+## Raw HTTP access
+
+Use the HTTP primitives when you need an endpoint not covered by a named method:
+
+```php
+// GET with query parameters
+$result = TOPDesk::get('api/incidents/call_types');
+
+// POST with a JSON body
+$result = TOPDesk::post('api/some/endpoint', ['key' => 'value']);
+
+// PUT / PATCH / DELETE
+TOPDesk::put('api/resource/'.$id, $data);
+TOPDesk::patch('api/resource/'.$id, $data);
+TOPDesk::delete('api/resource/'.$id);
+```
+
+All return a decoded `object`. A 204 No Content response returns an empty `array`. Any 4xx/5xx status throws `Illuminate\Http\Client\RequestException`.
+
+### Access the underlying PendingRequest
+
+`TOPDesk::query()` returns a pre-authenticated `PendingRequest` (base URL, basic auth, and `Accept: application/json` already set):
+
+```php
+// Multipart / file upload
+$response = TOPDesk::query()
+    ->attach('file', file_get_contents($path), 'report.pdf')
+    ->post('api/incidents/'.$incidentId.'/attachments');
+
+// Custom headers
+$response = TOPDesk::query()
+    ->withHeader('X-Custom', 'value')
+    ->get('api/some/endpoint');
+
+// Stream a response
+TOPDesk::query()
+    ->sink(storage_path('app/export.csv'))
+    ->get('api/export');
+```
+
+---
+
+## Models
+
+Models provide a typed, cache-backed way to look up entities without knowing their API endpoint.
+
+### Available models
+
+| Model | Entity |
+|---|---|
+| `Asset` | Asset management assets |
+| `Branch` | Branches |
+| `Location` | Locations |
+| `Operator` | Operators |
+| `OperatorGroup` | Operator groups |
+| `Person` | Persons |
+| `PersonGroup` | Person groups |
+| `Supplier` | Suppliers |
+
+### Usage
+
+```php
+use FredBradley\TOPDesk\Models\Person;
+use FredBradley\TOPDesk\Models\Operator;
+
+// Fetch by UUID (5-minute cache)
+$person = Person::findById($uuid);
+
+// Shorthand alias for findById
+$person = Person::find($uuid);
+
+// Find the first match by any field
+$operator = Operator::findFirstByVariable('networkLoginName', 'jsmith');
+
+// Filtered collection — all matches
+$people = Person::whereVariableEquals('surName', 'Smith');
+// Returns: Collection of Person instances
+
+// Force-refresh the cache
+$person = Person::findById($uuid, forgetCache: true);
+```
+
+Properties are assigned dynamically from the API JSON response, so you access them as plain object properties:
+
+```php
+echo $person->id;
+echo $person->surName;
+echo $person->email;
+```
+
+---
+
+## General API methods
+
+```php
+// TOPdesk API version string
+$version = TOPDesk::getApiVersion();
+
+// Full product version object
+$product = TOPDesk::getProductVersion();
+
+// Search across TOPdesk
+$results = TOPDesk::search('printer jam', 'incidents', start: 0);
+$results = TOPDesk::search('London', 'branches');
+
+// Service windows
+$windows = TOPDesk::getServiceWindows();
+$window  = TOPDesk::getServiceWindow($windowId);
+
+// Email items
+$email = TOPDesk::getEmail($emailId);
+TOPDesk::deleteEmail($emailId);
+```
+
+---
+
+## Error handling
+
+All HTTP errors surface as `Illuminate\Http\Client\RequestException`. Domain-specific exceptions are thrown before the HTTP call for lookup failures:
+
+| Exception | When thrown |
+|---|---|
+| `ConfigNotFound` | A required config value is missing or empty at boot |
+| `PersonNotFound` | `getPersonByUsername()` finds no match |
+| `OperatorNotFound` | Operator lookup finds no match |
+| `OperatorGroupNotFound` | `getOperatorGroupId()` finds no match |
+
+```php
+use FredBradley\TOPDesk\Exceptions\PersonNotFound;
+use Illuminate\Http\Client\RequestException;
+
+try {
+    $person = TOPDesk::getPersonByUsername($username);
+} catch (PersonNotFound $e) {
+    // HTTP 404 — person not in TOPdesk
+} catch (RequestException $e) {
+    // 4xx/5xx from the API
+    $statusCode = $e->response->status();
+}
+```
+
+---
+
+## Testing
+
+The package uses Laravel's HTTP fake, so you can stub responses in tests without hitting the API:
+
+```php
+use Illuminate\Support\Facades\Http;
+
+Http::fake([
+    '*/api/persons*' => Http::response([
+        ['id' => 'abc-123', 'surName' => 'Smith', 'networkLoginName' => 'jsmith'],
+    ]),
+]);
+
+$person = TOPDesk::getPersonByUsername('jsmith');
+
+Http::assertSent(fn ($request) => str_contains($request->url(), 'api/persons'));
+```

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,163 @@
+# Assets
+
+## Fetching assets
+
+```php
+// Single asset by UUID
+$asset = TOPDesk::getAsset($assetId);
+
+// List assets with optional filters
+$assets = TOPDesk::getListOfAssets([
+    'templateId' => $templateId,
+    'archived'   => false,
+]);
+```
+
+---
+
+## Creating and updating assets
+
+### Via template
+
+Assets are created against a specific template that defines their fields.
+
+```php
+// Resolve the template UUID by name (cached for 30 days)
+$templateId = TOPDesk::getAssetTemplateId('Laptop');
+
+$asset = TOPDesk::createAssetByTemplateId($templateId, [
+    'name'         => 'LAPTOP-0042',
+    'serialNumber' => 'SN123456',
+]);
+
+TOPDesk::updateAssetByTemplateId($templateId, $asset->id, [
+    'serialNumber' => 'SN999999',
+]);
+```
+
+### Direct update
+
+The Asset Management API uses POST (not PATCH) for field-level updates on individual assets.
+
+```php
+TOPDesk::updateAsset($assetId, [
+    'name' => 'LAPTOP-0042-RENAMED',
+]);
+```
+
+---
+
+## Copying, archiving, and deleting
+
+```php
+TOPDesk::copyAsset($assetId);
+
+TOPDesk::archiveAsset($assetId);
+TOPDesk::unarchiveAsset($assetId);
+
+// Delete one or more assets by UUID
+TOPDesk::deleteAssets([$assetId1, $assetId2]);
+```
+
+---
+
+## Assignments
+
+Assignments link an asset to a person, branch, location, or person group.
+
+```php
+// Current assignments for an asset
+$assignments = TOPDesk::getAssetAssignments($assetId);
+
+// Add an assignment
+TOPDesk::addAssetAssignment($assetId, [
+    'person' => ['id' => $personId],
+]);
+
+// Or assign to a branch/location/person group
+TOPDesk::addAssetAssignment($assetId, [
+    'branch'   => ['id' => $branchId],
+    'location' => ['id' => $locationId],
+]);
+
+// Remove an assignment
+TOPDesk::removeAssetAssignment($assetId, $linkId);
+```
+
+---
+
+## Asset links (relationships between assets)
+
+```php
+// List links — filter by source, target, or capability
+$links = TOPDesk::getAssetLinks(['sourceId' => $assetId]);
+
+// Create a link between two assets
+TOPDesk::createAssetLink([
+    'sourceId'     => $assetId,
+    'targetId'     => $otherAssetId,
+    'capabilityId' => $capabilityId,
+]);
+
+TOPDesk::deleteAssetLink($relationId);
+```
+
+---
+
+## Linking incidents to assets
+
+```php
+// Assign an incident to an asset (adds to the asset's linked incidents)
+TOPDesk::assignIncidentToAsset($assetId, $incidentId);
+
+// Link using the task-linking endpoint
+TOPDesk::linkIncidentToAsset($assetId, $incidentId);
+```
+
+---
+
+## History
+
+```php
+// Full history of changes to an asset
+$history = TOPDesk::getAssetHistory($assetId);
+
+// Current field values snapshot
+$current = TOPDesk::getAssetCurrentItems($assetId);
+```
+
+---
+
+## Lookup lists
+
+```php
+// Asset statuses (e.g. In use, In stock, Broken)
+$statuses = TOPDesk::getAssetStatuses();
+
+// Card types
+$cardTypes = TOPDesk::getCardTypes();
+
+// All available asset templates
+$templates = TOPDesk::getAssetTemplates();
+
+// Archived templates
+$archived = TOPDesk::getAssetTemplates(['archived' => true]);
+```
+
+Pass `forgetCache: true` to any of these to bust the cache:
+
+```php
+$statuses = TOPDesk::getAssetStatuses(forgetCache: true);
+```
+
+---
+
+## Using the Asset model
+
+```php
+use FredBradley\TOPDesk\Models\Asset;
+
+$asset = Asset::findById($assetId);
+
+$matches = Asset::whereVariableEquals('serialNumber', 'SN123456');
+```

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,53 @@
+# Caching
+
+The package uses Laravel's `Cache` facade. Any cache driver configured in your Laravel application will be used automatically.
+
+## Default TTLs
+
+| Data type | TTL |
+|---|---|
+| Lookup lists (call types, impacts, etc.) | 1 week |
+| Asset templates | 1 week |
+| Asset template IDs | 30 days |
+| Operator/person queries | 5 minutes |
+| Incident counts | 5 minutes |
+| Change activities | 10 minutes (open) / 1 hour (per-operator) |
+
+## Busting the cache per call
+
+Most methods that cache accept a `bool $forgetCache = false` parameter. Pass `true` to clear the cached entry and fetch fresh data:
+
+```php
+$types    = TOPDesk::getCallTypes(forgetCache: true);
+$operator = TOPDesk::getOperatorByUsername('jsmith', forgetCache: true);
+$groupId  = TOPDesk::getOperatorGroupId('I.T. Services', forgetCache: true);
+```
+
+## Disabling cache globally
+
+Set the environment variable to disable caching entirely:
+
+```env
+TOPdesk_ignore_cache=true
+```
+
+When this is `true`, every call to `setupCacheObject()` clears the key before `Cache::remember()` runs, effectively making every request hit the API.
+
+## How it works internally
+
+The `setupCacheObject(string $cacheKey, bool $forgetCache): string` method is the single cache-busting entry point used by all traits. It:
+
+1. Checks `$forgetCache` and the `topdesk.ignore_cache` config flag.
+2. Calls `Cache::forget($cacheKey)` if either is true.
+3. Returns the key unchanged — the calling code then passes it to `Cache::remember()`.
+
+This means the forget-then-remember pattern is used throughout, rather than conditional logic scattered across traits.
+
+## Cache keys
+
+Keys are constructed from the endpoint and query variable names, slugified with `Str::slug()`. For example:
+
+- `assetStatuses`
+- `asset_templates`
+- `get_operators_{operatorGroupId}`
+- `operatorgroups-name-i-t-services`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,41 @@
+# Change Management
+
+Change activities represent planned work items within TOPdesk's change management module.
+
+## Listing change activities
+
+```php
+// All open, unblocked, unarchived change activities (sorted by planned final date)
+$activities = TOPDesk::allOpenChangeActivities();
+
+// Open activities assigned to a specific operator group
+$unassigned = TOPDesk::unassignedWaitingChangeActivities('I.T. Services');
+
+// Open activities for a specific operator (by username)
+$mine = TOPDesk::waitingChangeActivitiesByUsername('jsmith');
+
+// Open activities for a specific operator (by UUID)
+$mine = TOPDesk::waitingChangeActivitiesByOperatorId($operatorId);
+```
+
+All methods return a `Collection` of activity objects from the API.
+
+## Resolved activities
+
+```php
+// Resolved activities for an operator within a time window
+$resolved = TOPDesk::resolvedChangeActivitiesByOperatorIdByTime($operatorId, 'Week');
+$resolved = TOPDesk::resolvedChangeActivitiesByOperatorIdByTime($operatorId, 'Month');
+```
+
+The `$timeString` is passed to Carbon's `startOf()` method, so valid values are `'Day'`, `'Week'`, `'Month'`, `'Year'`, etc.
+
+## Counts
+
+```php
+$count = TOPDesk::countWaitingChangeActivitiesByOperatorId($operatorId);
+```
+
+## Caching
+
+All change activity methods cache their results for 10 minutes (open lists) or 1 hour (per-operator lists). Force-refresh is not currently exposed but you can clear cache keys manually or set `TOPdesk_ignore_cache=true` in your environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,76 @@
+# Getting Started
+
+## Requirements
+
+- PHP 8.2 or higher
+- Laravel 9–13
+
+## Installation
+
+```bash
+composer require fredbradley/topdesk
+```
+
+Laravel's package auto-discovery registers the service provider and `TOPDesk` facade alias automatically.
+
+## Configuration
+
+Publish the config file:
+
+```bash
+php artisan vendor:publish --tag=topdesk.config
+```
+
+Add the following to your `.env`:
+
+```env
+TOPdesk_endpoint=https://yourcompany.topdesk.net/tas/
+TOPdesk_app_username=api-user@yourcompany.com
+TOPdesk_app_password=your-application-password
+TOPdesk_ignore_cache=false
+```
+
+> **Note:** The endpoint must end with `tas/`. Application passwords are created in TOPdesk under _My Settings → Application passwords_.
+
+If any of the three required values are missing or empty the package throws `ConfigNotFound` at boot time, so misconfiguration is caught early rather than at the first API call.
+
+## Basic usage
+
+All methods are available through the `TOPDesk` facade:
+
+```php
+use FredBradley\TOPDesk\Facades\TOPDesk;
+
+// Fetch a person by their network login name
+$person = TOPDesk::getPersonByUsername('jsmith');
+
+// Create an incident
+$incident = TOPDesk::createIncident([
+    'callerLookup' => ['id' => $person->id],
+    'briefDescription' => 'Printer not working',
+    'entryType' => ['name' => 'Chat'],
+]);
+
+// Retrieve it back
+$incident = TOPDesk::getIncident($incident->number);
+```
+
+## Raw HTTP access
+
+For any endpoint not covered by a named method, use the HTTP primitives directly:
+
+```php
+$result = TOPDesk::get('api/incidents/call_types');
+
+$created = TOPDesk::post('api/someEndpoint', ['key' => 'value']);
+```
+
+`get`, `post`, `put`, `patch`, and `delete` all return a decoded `object` (or an empty `array` for 204 No Content responses). Any 4xx/5xx response throws an `Illuminate\Http\Client\RequestException`.
+
+If you need access to the raw `PendingRequest` to set custom headers or send multipart data:
+
+```php
+$response = TOPDesk::query()
+    ->attach('file', file_get_contents($path), 'attachment.pdf')
+    ->post('api/incidents/'.$incidentId.'/attachments');
+```

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -1,0 +1,222 @@
+# Incidents
+
+## CRUD
+
+### List incidents
+
+```php
+$incidents = TOPDesk::getListOfIncidents([
+    'start'     => 0,
+    'page_size' => 50,
+    'status'    => 'firstLine',
+]);
+```
+
+Accepts all query parameters documented in the TOPdesk REST API (page_size, start, status, category, subcategory, operator, operatorGroup, caller, etc.).
+
+### Fetch a single incident
+
+```php
+// By incident number (e.g. "I-1234-56789")
+$incident = TOPDesk::getIncident('I-1234-56789');
+```
+
+### Create an incident
+
+```php
+$incident = TOPDesk::createIncident([
+    'callerLookup'     => ['id' => $personId],
+    'briefDescription' => 'Email not working',
+    'entryType'        => ['name' => 'Phone'],
+    'category'         => ['name' => 'Software'],
+    'subcategory'      => ['name' => 'Email'],
+    'operatorGroup'    => ['id' => $groupId],
+]);
+
+echo $incident->number; // "I-2024-00001"
+echo $incident->id;
+```
+
+### Update an incident
+
+```php
+// By UUID
+TOPDesk::updateIncident($incident->id, [
+    'briefDescription' => 'Updated description',
+    'operator'         => ['id' => $operatorId],
+]);
+
+// By incident number
+TOPDesk::updateIncidentByNumber('I-1234-56789', [
+    'processingStatus' => ['name' => 'Resolved'],
+]);
+```
+
+---
+
+## Actions, requests, and progress trail
+
+### Progress trail
+
+```php
+$trail = TOPDesk::getProgressTrail($incidentId);
+
+// By incident number
+$trail = TOPDesk::getProgressTrailByNumber('I-1234-56789');
+
+// Count only
+$count = TOPDesk::getProgressTrailCount($incidentId);
+```
+
+### Operator actions
+
+Actions are operator-visible notes attached to an incident.
+
+```php
+$actions = TOPDesk::getIncidentActions($incidentId);
+
+$action = TOPDesk::getIncidentAction($incidentId, $actionId);
+
+TOPDesk::deleteIncidentAction($incidentId, $actionId);
+```
+
+### Caller requests
+
+Requests are the caller-visible side of the conversation.
+
+```php
+$requests = TOPDesk::getIncidentRequests($incidentId);
+
+$request = TOPDesk::getIncidentRequest($incidentId, $requestId);
+
+TOPDesk::deleteIncidentRequest($incidentId, $requestId);
+```
+
+### Attachments
+
+```php
+$attachments = TOPDesk::getIncidentAttachments($incidentId);
+
+// By incident number
+$attachments = TOPDesk::getIncidentAttachmentsByNumber('I-1234-56789');
+
+TOPDesk::deleteIncidentAttachment($incidentId, $attachmentId);
+```
+
+---
+
+## Time registration
+
+```php
+// Register time spent on an incident
+TOPDesk::registerTimeSpent($incidentId, [
+    'timeSpent'    => 30,       // minutes
+    'enteredDate'  => '2024-06-01',
+    'operator'     => ['id' => $operatorId],
+    'reason'       => ['id' => $reasonId],
+]);
+
+// Fetch all time registrations for an incident
+$timeEntries = TOPDesk::getTimeSpent($incidentId);
+
+// Browse all time registrations across incidents
+$all = TOPDesk::getTimeRegistrations(['pageSize' => 100]);
+$entry = TOPDesk::getTimeRegistration($registrationId);
+```
+
+---
+
+## Escalation and de-escalation
+
+```php
+// Get available reasons first
+$reasons = TOPDesk::getEscalationReasons();
+$reasonId = $reasons->where('name', 'SLA breach')->first()['id'];
+
+TOPDesk::escalateIncident($incidentId, $reasonId);
+TOPDesk::escalateIncidentByNumber('I-1234-56789', $reasonId);
+
+$deReasons = TOPDesk::getDeescalationReasons();
+TOPDesk::deescalateIncident($incidentId, $deReasonId);
+```
+
+---
+
+## Archiving
+
+```php
+// Get available archive reasons
+$reasons    = TOPDesk::getArchiveReasons();
+$reasonId   = TOPDesk::getArchiveReasonId('Duplicate');
+
+TOPDesk::archiveIncident($incidentId, $reasonId);
+TOPDesk::archiveIncidentByNumber('I-1234-56789', $reasonId);
+
+TOPDesk::unarchiveIncident($incidentId);
+TOPDesk::unarchiveIncidentByNumber('I-1234-56789');
+```
+
+---
+
+## Lookup lists
+
+These return cached `Collection` instances with `id` and `name` keys.
+
+```php
+TOPDesk::getCallTypes();
+TOPDesk::getEntryTypes();
+TOPDesk::getDurations();
+TOPDesk::getImpacts();
+TOPDesk::getPriorities();
+TOPDesk::getUrgencies();
+TOPDesk::getClosureCodes();
+TOPDesk::getEscalationReasons();
+TOPDesk::getDeescalationReasons();
+TOPDesk::getTimeSpentReasons();
+TOPDesk::getCategories();
+TOPDesk::getSlas();
+TOPDesk::getSlaServices();
+TOPDesk::getAllProcessingStatuses();
+```
+
+Pass `true` to force-refresh a cached list:
+
+```php
+$fresh = TOPDesk::getCallTypes(forgetCache: true);
+```
+
+### Resolve a processing status ID by name
+
+```php
+$statusId = TOPDesk::getProcessingStatusId('Waiting for user');
+```
+
+---
+
+## Filtering with FIQL
+
+TOPdesk uses FIQL (Feed Item Query Language) for filtering. Pass a `query` string in the options array:
+
+```php
+$open = TOPDesk::getListOfIncidents([
+    'query' => '(processingStatus.name==Open);(operatorGroup.name==I.T. Services)',
+]);
+
+$count = TOPDesk::getNumIncidents(
+    '(processingStatus.name==Open);(operator.id=='.$operatorId.')'
+);
+```
+
+Operators: `==` (equals), `!=` (not equals), `=in=` (in list), `=out=` (not in list), `;` (AND), `,` (OR).
+
+---
+
+## Open incidents by operator group
+
+```php
+$incidents = TOPDesk::getOpenIncidentsByOperatorGroupId(
+    operatorGroupId: $groupId,
+    processingStatus: 'Open',
+    forgetCache: false,
+);
+```

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -1,0 +1,142 @@
+# Operators
+
+## Looking up operators
+
+```php
+// By network login name (cached)
+$operator = TOPDesk::getOperatorByUsername('jsmith');
+
+// By UUID — optionally limit fields returned
+$operator = TOPDesk::getOperatorById($uuid, fields: ['id', 'name', 'email']);
+
+// The authenticated API user's own operator record
+$me = TOPDesk::getCurrentOperator();
+
+// Just the UUID of the current operator
+$myId = TOPDesk::getCurrentOperatorId();
+
+// Typeahead/lookup list
+$results = TOPDesk::getOperatorLookup(['query' => 'Jane']);
+```
+
+---
+
+## Creating and updating operators
+
+```php
+$operator = TOPDesk::createOperator([
+    'surName'          => 'Doe',
+    'firstName'        => 'Jane',
+    'networkLoginName' => 'jdoe',
+    'email'            => 'jdoe@example.com',
+]);
+
+TOPDesk::updateOperator($operator->id, [
+    'phoneNumber' => '+44 1234 000000',
+]);
+```
+
+---
+
+## Archiving
+
+```php
+TOPDesk::archiveOperator($operatorId);
+TOPDesk::unarchiveOperator($operatorId);
+```
+
+---
+
+## Operator groups
+
+```php
+// List all operator groups
+$groups = TOPDesk::getOperatorGroups();
+
+// Single group by UUID
+$group = TOPDesk::getOperatorGroupById($groupId);
+
+// Resolve a group UUID by its display name (cached)
+$groupId = TOPDesk::getOperatorGroupId('I.T. Services');
+
+// All operators in a group (by display name)
+$operators = TOPDesk::getOperatorsByOperatorGroup('I.T. Services');
+
+// All operators in a group (by UUID)
+$operators = TOPDesk::getOperatorGroupOperators($groupId);
+
+// Typeahead/lookup list
+$lookup = TOPDesk::getOperatorGroupLookup(['query' => 'IT']);
+```
+
+### Managing operator groups
+
+```php
+$group = TOPDesk::createOperatorGroup(['groupName' => 'Networking']);
+
+TOPDesk::updateOperatorGroup($groupId, ['groupName' => 'Network & Infrastructure']);
+
+TOPDesk::archiveOperatorGroup($groupId);
+TOPDesk::unarchiveOperatorGroup($groupId);
+```
+
+---
+
+## Permission groups
+
+```php
+$permissions = TOPDesk::getPermissionGroups();
+```
+
+---
+
+## Operator statistics
+
+These methods give per-operator and per-group counts, useful for dashboards.
+
+### Counts by operator group
+
+```php
+// Open ticket count per operator in a group
+$openCounts = TOPDesk::openCountsForOperatorGroup('I.T. Services');
+// Returns: ['jsmith' => 12, 'jdoe' => 7, ...]
+
+// Active (in-progress) ticket count per operator
+$activeCounts = TOPDesk::activeCountsForOperatorGroup('I.T. Services');
+
+// Closed ticket count per operator (day / week / month / total)
+$closedCounts = TOPDesk::closedTicketCountsForOperatorGroup('I.T. Services');
+
+// Exclude specific operators
+$counts = TOPDesk::openCountsForOperatorGroup(
+    name: 'I.T. Services',
+    ignoreUsernames: ['api-user', 'monitoring'],
+);
+```
+
+### Counts per operator
+
+```php
+// Returns array with closed_day, closed_week, closed_month, closed_total, open
+$stats = TOPDesk::getClosedIncidentsForOperator($operatorId);
+
+$openCount   = TOPDesk::countOpenTicketsByOperator($operatorId);
+$activeCount = TOPDesk::countActiveTicketsbyOperator($operatorId);
+
+// Closed count within a time period
+$weekCount = TOPDesk::countClosedTicketsByTime($operatorId, 'week');
+$monthCount = TOPDesk::countClosedTicketsByTime($operatorId, 'month');
+```
+
+---
+
+## Using the Operator model
+
+```php
+use FredBradley\TOPDesk\Models\Operator;
+
+$operator = Operator::findById($uuid);
+$operator = Operator::findFirstByVariable('networkLoginName', 'jsmith');
+
+$matches = Operator::whereVariableEquals('surName', 'Doe');
+```

--- a/docs/people.md
+++ b/docs/people.md
@@ -1,0 +1,111 @@
+# People
+
+## Looking up persons
+
+```php
+// By network login name (throws PersonNotFound if no match)
+$person = TOPDesk::getPersonByUsername('jsmith');
+
+// By TOPdesk person UUID
+$person = TOPDesk::getPersonById($uuid);
+
+// The authenticated API user's own person record
+$me = TOPDesk::getCurrentPerson();
+```
+
+`getPersonByUsername` throws `FredBradley\TOPDesk\Exceptions\PersonNotFound` (HTTP 404) when the username is not found, so you can catch it at the HTTP layer:
+
+```php
+try {
+    $person = TOPDesk::getPersonByUsername($username);
+} catch (\FredBradley\TOPDesk\Exceptions\PersonNotFound $e) {
+    // 404 response — person does not exist in TOPdesk
+}
+```
+
+---
+
+## Creating and updating persons
+
+```php
+$person = TOPDesk::createPerson([
+    'surName'          => 'Smith',
+    'firstName'        => 'John',
+    'networkLoginName' => 'jsmith',
+    'email'            => 'jsmith@example.com',
+    'branch'           => ['id' => $branchId],
+]);
+
+TOPDesk::updatePerson($person->id, [
+    'phoneNumber' => '+44 1234 567890',
+    'department'  => ['id' => $departmentId],
+]);
+```
+
+---
+
+## Archiving
+
+```php
+TOPDesk::archivePerson($personId);
+TOPDesk::unarchivePerson($personId);
+```
+
+---
+
+## Counts and lookups
+
+```php
+// Total number of persons in the system
+$total = TOPDesk::getPersonCount();
+
+// Typeahead/lookup list (e.g. for autocomplete)
+$results = TOPDesk::getPersonLookup(['query' => 'Smith']);
+```
+
+---
+
+## Person groups
+
+```php
+// List all person groups
+$groups = TOPDesk::getPersonGroups();
+
+// Single group by UUID
+$group = TOPDesk::getPersonGroup($groupId);
+
+// Members of a group
+$members = TOPDesk::getPersonGroupPersons($groupId);
+
+// Groups a specific person belongs to
+$myGroups = TOPDesk::getPersonGroupsForPerson($personId);
+```
+
+### Managing person groups
+
+```php
+$group = TOPDesk::createPersonGroup(['groupName' => 'Finance']);
+
+TOPDesk::updatePersonGroup($groupId, ['groupName' => 'Finance & Payroll']);
+
+TOPDesk::archivePersonGroup($groupId);
+TOPDesk::unarchivePersonGroup($groupId);
+
+$lookup = TOPDesk::getPersonGroupLookup(['query' => 'Fin']);
+```
+
+---
+
+## Using the Person model
+
+The `Person` model wraps the API with a 5-minute cache and typed access:
+
+```php
+use FredBradley\TOPDesk\Models\Person;
+
+$person = Person::findById($uuid);
+$person = Person::findFirstByVariable('networkLoginName', 'jsmith');
+
+// Filtered collection
+$matches = Person::whereVariableEquals('surName', 'Smith');
+```

--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -1,0 +1,100 @@
+# Statistics and Counts
+
+These methods are useful for building dashboards, reports, and monitors.
+
+## Incident counts by operator group
+
+```php
+// Tickets logged today
+$count = TOPDesk::countTicketsLoggedtoday('I.T. Services');
+
+// Currently open tickets
+$count = TOPDesk::countOpenTickets('I.T. Services');
+
+// Tickets due this week
+$count = TOPDesk::countTicketsDueThisWeek('I.T. Services');
+
+// Tickets that have breached their SLA
+$count = TOPDesk::countBreachedTickets('I.T. Services');
+
+// Unassigned tickets in a group
+$count = TOPDesk::countUnassignedTickets('I.T. Services');
+
+// Count by a specific processing status name
+$count = TOPDesk::countTicketsByStatus('Waiting for user', 'I.T. Services');
+
+// Count by processing status UUID
+$statusId = TOPDesk::getProcessingStatusId('Waiting for user');
+$count    = TOPDesk::countByProcessingStatusId($statusId, 'I.T. Services');
+```
+
+## FIQL-based count
+
+For precise filtering, use `getNumIncidents` with a FIQL query string:
+
+```php
+$count = TOPDesk::getNumIncidents(
+    '(processingStatus.name==Open);(operatorGroup.name==I.T. Services)'
+);
+
+$count = TOPDesk::getNumIncidents(
+    '(caller.id=='.$personId.')',
+    ['pageSize' => 1],
+);
+```
+
+## Counts per operator
+
+```php
+$openCount   = TOPDesk::countOpenTicketsByOperator($operatorId);
+$activeCount = TOPDesk::countActiveTicketsbyOperator($operatorId);
+
+// Closed within a time window ('day', 'week', 'month')
+$weekCount = TOPDesk::countClosedTicketsByTime($operatorId, 'week');
+
+// Resolved change activities for an operator
+$changeCount = TOPDesk::countResolvesByTime($operatorId, 'week');
+
+// Waiting change activities for an operator
+$waitingCount = TOPDesk::countWaitingChangeActivitiesByOperatorId($operatorId);
+```
+
+## Per-operator breakdown for a group
+
+These methods return an associative array keyed by network login name:
+
+```php
+// Open ticket count per operator
+$openCounts = TOPDesk::openCountsForOperatorGroup('I.T. Services');
+// ['jsmith' => 5, 'jdoe' => 12, ...]
+
+// Active (in-progress) ticket count per operator
+$activeCounts = TOPDesk::activeCountsForOperatorGroup('I.T. Services');
+
+// Closed ticket counts per operator (day/week/month/total + open)
+$closedCounts = TOPDesk::closedTicketCountsForOperatorGroup('I.T. Services');
+// ['jsmith' => ['closed_day' => 3, 'closed_week' => 18, ...], ...]
+
+// Exclude service accounts or absent operators
+$counts = TOPDesk::openCountsForOperatorGroup(
+    name: 'I.T. Services',
+    ignoreUsernames: ['api-bot', 'monitoring'],
+);
+```
+
+## Full closed-incident stats for one operator
+
+```php
+$stats = TOPDesk::getClosedIncidentsForOperator($operatorId);
+
+// Returns:
+// [
+//   'closed_day'   => 3,
+//   'closed_week'  => 18,
+//   'closed_month' => 67,
+//   'closed_total' => 412,
+//   'open'         => 5,
+// ]
+```
+
+Results are cached for 5 minutes.

--- a/docs/supporting-files.md
+++ b/docs/supporting-files.md
@@ -1,0 +1,149 @@
+# Supporting Files
+
+Supporting files are the reference data that incidents, persons, and assets are linked to: branches, locations, departments, and suppliers.
+
+---
+
+## Branches
+
+```php
+// List branches (optionally filter)
+$branches = TOPDesk::getBranches(['query' => 'London']);
+
+// Single branch by UUID
+$branch = TOPDesk::getBranch($branchId);
+
+// Resolve a branch UUID by display name (cached)
+$branchId = TOPDesk::getBranchId('London HQ');
+
+// Typeahead/lookup list
+$lookup = TOPDesk::getBranchLookup(['query' => 'Lon']);
+```
+
+### Creating and updating branches
+
+```php
+$branch = TOPDesk::createBranch([
+    'name'    => 'Manchester Office',
+    'country' => ['id' => $countryId],
+]);
+
+TOPDesk::updateBranch($branchId, ['phone' => '+44 161 000 0000']);
+
+TOPDesk::archiveBranch($branchId);
+TOPDesk::unarchiveBranch($branchId);
+```
+
+### Branch metadata
+
+```php
+$designations   = TOPDesk::getBranchDesignations();
+$buildingLevels = TOPDesk::getBranchBuildingLevels();
+```
+
+### Branch attachments
+
+```php
+$attachments = TOPDesk::getBranchAttachments($branchId);
+TOPDesk::deleteBranchAttachment($branchId, $attachmentId);
+```
+
+---
+
+## Locations
+
+```php
+$locations = TOPDesk::getLocations(['query' => 'Floor 3']);
+
+$location = TOPDesk::getLocation($locationId);
+
+$lookup = TOPDesk::getLocationLookup(['query' => 'Floor']);
+```
+
+### Creating and updating locations
+
+```php
+$location = TOPDesk::createLocation([
+    'name'   => 'Floor 3 - East Wing',
+    'branch' => ['id' => $branchId],
+]);
+
+TOPDesk::updateLocation($locationId, ['name' => 'Floor 3 - West Wing']);
+
+TOPDesk::archiveLocation($locationId);
+TOPDesk::unarchiveLocation($locationId);
+```
+
+### Location lookup lists
+
+```php
+$types    = TOPDesk::getLocationTypes();
+$statuses = TOPDesk::getLocationStatuses();
+$zones    = TOPDesk::getBuildingZones();
+```
+
+---
+
+## Departments
+
+```php
+$departments = TOPDesk::getDepartments();
+
+$dept = TOPDesk::createDepartment('Finance');
+
+TOPDesk::updateDepartment($deptId, 'Finance & Payroll');
+
+TOPDesk::archiveDepartment($deptId);
+TOPDesk::unarchiveDepartment($deptId);
+TOPDesk::deleteDepartment($deptId);
+```
+
+---
+
+## Suppliers
+
+```php
+$suppliers = TOPDesk::getSuppliers(['query' => 'Dell']);
+
+$supplier = TOPDesk::getSupplier($supplierId);
+
+// Typeahead/lookup list (cached)
+$lookup = TOPDesk::getSupplierLookup(['query' => 'Del']);
+```
+
+### Supplier contacts
+
+```php
+$contacts = TOPDesk::getSupplierContacts(['supplierId' => $supplierId]);
+
+$contact = TOPDesk::getSupplierContact($contactId);
+```
+
+---
+
+## Reference data
+
+```php
+// Countries (cached)
+$countries = TOPDesk::getCountries();
+
+// Languages (cached)
+$languages = TOPDesk::getLanguages();
+```
+
+---
+
+## Using models
+
+```php
+use FredBradley\TOPDesk\Models\Branch;
+use FredBradley\TOPDesk\Models\Location;
+use FredBradley\TOPDesk\Models\Supplier;
+
+$branch   = Branch::findById($branchId);
+$location = Location::findById($locationId);
+$supplier = Supplier::findById($supplierId);
+
+// Filtered collection
+$branches = Branch::whereVariableEquals('name', 'London HQ');
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+>
     <testsuites>
-        <testsuite name="Package">
-            <directory suffix=".php">./tests/</directory>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-        </whitelist>
-    </filter>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Exceptions/ConfigNotFound.php
+++ b/src/Exceptions/ConfigNotFound.php
@@ -6,6 +6,4 @@ namespace FredBradley\TOPDesk\Exceptions;
 
 // Pattern: exception classes only need a body when they add behaviour beyond their parent.
 // An empty class body inherits Exception's full constructor/message handling for free.
-class ConfigNotFound extends \RuntimeException
-{
-}
+class ConfigNotFound extends \RuntimeException {}

--- a/src/Exceptions/ConfigNotFound.php
+++ b/src/Exceptions/ConfigNotFound.php
@@ -1,13 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Exceptions;
 
-use Throwable;
-
-class ConfigNotFound extends \Exception
-{
-    public function __construct($message = '', $code = 0, ?Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-    }
-}
+// Pattern: exception classes only need a body when they add behaviour beyond their parent.
+// An empty class body inherits Exception's full constructor/message handling for free.
+class ConfigNotFound extends \RuntimeException {}

--- a/src/Exceptions/ConfigNotFound.php
+++ b/src/Exceptions/ConfigNotFound.php
@@ -6,4 +6,6 @@ namespace FredBradley\TOPDesk\Exceptions;
 
 // Pattern: exception classes only need a body when they add behaviour beyond their parent.
 // An empty class body inherits Exception's full constructor/message handling for free.
-class ConfigNotFound extends \RuntimeException {}
+class ConfigNotFound extends \RuntimeException
+{
+}

--- a/src/Exceptions/OperatorGroupNotFound.php
+++ b/src/Exceptions/OperatorGroupNotFound.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorGroupNotFound extends \Exception {}
+class OperatorGroupNotFound extends \Exception
+{
+}

--- a/src/Exceptions/OperatorGroupNotFound.php
+++ b/src/Exceptions/OperatorGroupNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorGroupNotFound extends \Exception
-{
-}
+class OperatorGroupNotFound extends \Exception {}

--- a/src/Exceptions/OperatorGroupNotFound.php
+++ b/src/Exceptions/OperatorGroupNotFound.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorGroupNotFound extends \Exception
-{
-}
+class OperatorGroupNotFound extends \Exception {}

--- a/src/Exceptions/OperatorNotFound.php
+++ b/src/Exceptions/OperatorNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorNotFound extends \Exception
-{
-}
+class OperatorNotFound extends \Exception {}

--- a/src/Exceptions/OperatorNotFound.php
+++ b/src/Exceptions/OperatorNotFound.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorNotFound extends \Exception {}
+class OperatorNotFound extends \Exception
+{
+}

--- a/src/Exceptions/OperatorNotFound.php
+++ b/src/Exceptions/OperatorNotFound.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Exceptions;
 
-class OperatorNotFound extends \Exception
-{
-}
+class OperatorNotFound extends \Exception {}

--- a/src/Exceptions/PersonNotFound.php
+++ b/src/Exceptions/PersonNotFound.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Exceptions;
+
+/**
+ * Thrown when a person lookup returns no results.
+ * Carries HTTP 404 so callers can map it to a response code directly.
+ */
+class PersonNotFound extends \RuntimeException
+{
+    public function __construct(string $identifier)
+    {
+        parent::__construct("Person not found: {$identifier}", 404);
+    }
+}

--- a/src/Facades/TOPDesk.php
+++ b/src/Facades/TOPDesk.php
@@ -1,28 +1,112 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-/**
- * @method static get(string $string, int[] $array): object
- * @method static post(string $string, array $array): object
- * @method static request(string $string, string $string1, string[] $array): object
- * @method static patch(string $string, array $array): object
- * @method static getProcessingStatusid(string $string): object
- * @method static createIncident(array $params): object
- * @method static getPersonByUsername(mixed $username)
- * @method static array|object updateAssetByTemplateId(string $templateId, string $assetID, array $data)
+/*
+ * Pattern: Facade @method docblocks document only the public surface that
+ * callers actually reach through the facade. IDE auto-completion and static
+ * analysis (PHPStan, Larastan) resolve these stubs to the concrete class, so
+ * each entry must match the real signature exactly. Group by domain for readability.
+ *
+ * --- HTTP primitives ---
+ * @method static array|object get(string $uri, array $query = [])
+ * @method static array|object post(string $uri, array $data = [])
+ * @method static array|object put(string $uri, array $data = [])
+ * @method static array|object patch(string $uri, array $data = [])
+ * @method static array|object delete(string $uri, array $data = [])
+ * @method static \Illuminate\Http\Client\PendingRequest query()
+ *
+ * --- Incidents ---
+ * @method static array|object getListOfIncidents(array $options = [])
+ * @method static object getIncident(string $topdeskIncidentNumber)
+ * @method static object createIncident(array $options)
+ * @method static object updateIncident(string $id, array $data)
+ * @method static object updateIncidentByNumber(string $number, array $data)
+ * @method static array|object archiveIncident(string $incidentId, string $reasonId)
+ * @method static array|object unarchiveIncident(string $incidentId)
+ * @method static array|object escalateIncident(string $incidentId, string $reasonId)
+ * @method static array|object deescalateIncident(string $incidentId, string $reasonId)
+ * @method static \Illuminate\Support\Collection getProgressTrail(string $incidentId, array $options = [])
+ * @method static \Illuminate\Support\Collection getIncidentActions(string $incidentId, array $options = [])
+ * @method static \Illuminate\Support\Collection getIncidentRequests(string $incidentId, array $options = [])
+ * @method static \Illuminate\Support\Collection getIncidentAttachments(string $incidentId, array $options = [])
+ * @method static object registerTimeSpent(string $incidentId, array $data)
+ * @method static \Illuminate\Support\Collection getTimeSpent(string $incidentId)
+ * @method static \Illuminate\Support\Collection getOpenIncidentsByOperatorGroupId(string $operatorGroupId, string $processingStatus = 'Open', bool $forgetCache = false)
+ * @method static int getNumIncidents(string $fiql, array $options = [])
+ *
+ * --- Incident lookups ---
+ * @method static \Illuminate\Support\Collection getCallTypes(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getDurations(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getEntryTypes(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getImpacts(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getPriorities(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getUrgencies(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getClosureCodes(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getEscalationReasons(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getDeescalationReasons(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getAllProcessingStatuses(bool $forgetCache = false)
+ * @method static string getProcessingStatusId(string $name, bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getSlas(array $options = [])
+ * @method static \Illuminate\Support\Collection getArchiveReasons()
+ * @method static string getArchiveReasonId(string $string)
+ *
+ * --- People ---
+ * @method static object getPersonByUsername(string $username)
+ * @method static object getPersonById(string $id)
+ * @method static object createPerson(array $data)
+ * @method static object updatePerson(string $id, array $data)
+ * @method static object getCurrentPerson()
+ * @method static \Illuminate\Support\Collection getPersonGroups(array $query = [])
+ *
+ * --- Operators ---
+ * @method static object getOperatorByUsername(string $username, bool $forgetCache = false)
+ * @method static object getOperatorById(string $id, array $fields = [])
+ * @method static object createOperator(array $data)
+ * @method static object getCurrentOperator(array $fields = [])
+ * @method static string getOperatorGroupId(string $name, bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getOperatorsByOperatorGroup(string $name)
+ * @method static \Illuminate\Support\Collection getOperatorGroups(array $query = [])
+ *
+ * --- Assets ---
+ * @method static object getAsset(string $assetId)
+ * @method static array|object getListOfAssets(array $query = [])
  * @method static array|object createAssetByTemplateId(string $templateId, array $data)
+ * @method static array|object updateAssetByTemplateId(string $templateId, string $assetID, array $data)
+ * @method static array|object updateAsset(string $assetId, array $data)
+ * @method static array|object archiveAsset(string $assetId)
+ * @method static array|object getAssetAssignments(string $assetId)
+ * @method static string getAssetTemplateId(string $name, bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getAssetStatuses(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getCardTypes(bool $forgetCache = false)
+ *
+ * --- Supporting files ---
+ * @method static \Illuminate\Support\Collection getBranches(array $query = [])
+ * @method static object getBranch(string $id)
+ * @method static object createBranch(array $data)
+ * @method static \Illuminate\Support\Collection getLocations(array $query = [])
+ * @method static object getLocation(string $id)
+ * @method static \Illuminate\Support\Collection getDepartments(array $query = [])
+ * @method static \Illuminate\Support\Collection getSuppliers(array $query = [])
+ * @method static object getSupplier(string $id)
+ *
+ * --- General ---
+ * @method static string getApiVersion()
+ * @method static object getProductVersion()
+ * @method static \Illuminate\Support\Collection search(string $query, string $index = 'incidents', int $start = 0)
+ * @method static \Illuminate\Support\Collection getCountries(bool $forgetCache = false)
+ * @method static \Illuminate\Support\Collection getLanguages(bool $forgetCache = false)
+ *
+ * --- Cache ---
+ * @method static string setupCacheObject(string $cacheKey, bool $forgetCache)
  */
 class TOPDesk extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'topdesk';
     }

--- a/src/Models/Asset.php
+++ b/src/Models/Asset.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Asset extends BaseModel {}
+class Asset extends BaseModel
+{
+}

--- a/src/Models/Asset.php
+++ b/src/Models/Asset.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Models;
 
-class Asset extends BaseModel
-{
-}
+class Asset extends BaseModel {}

--- a/src/Models/Asset.php
+++ b/src/Models/Asset.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Asset extends BaseModel
-{
-}
+class Asset extends BaseModel {}

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -7,7 +7,6 @@ namespace FredBradley\TOPDesk\Models;
 use FredBradley\EasyTime\EasySeconds;
 use FredBradley\TOPDesk\Facades\TOPDesk;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 abstract class BaseModel

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -64,7 +64,7 @@ abstract class BaseModel
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.$variableKey.$variableValue),
             forgetCache: $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
             $result = TOPDesk::query()->get('api/'.self::$endpoint.'/', [
                 'query' => $variableKey.'=='.$variableValue,
             ])->throw()->collect()->mapInto(self::$model);
@@ -79,7 +79,7 @@ abstract class BaseModel
 
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.'id'.$id), forgetCache: $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
             // Some APIs use /{id} directly; others use /id/{id}
             $noIdPrefix = [Asset::class, PersonGroup::class, Supplier::class];
             $endpoint = in_array(self::$model, $noIdPrefix)

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -63,7 +63,7 @@ abstract class BaseModel
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.$variableKey.$variableValue),
             forgetCache: $forgetCache);
 
-        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
+        return TOPDesk::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
             $result = TOPDesk::query()->get('api/'.self::$endpoint.'/', [
                 'query' => $variableKey.'=='.$variableValue,
             ])->throw()->collect()->mapInto(self::$model);
@@ -78,7 +78,7 @@ abstract class BaseModel
 
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.'id'.$id), forgetCache: $forgetCache);
 
-        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
+        return TOPDesk::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
             // Some APIs use /{id} directly; others use /id/{id}
             $noIdPrefix = [Asset::class, PersonGroup::class, Supplier::class];
             $endpoint = in_array(self::$model, $noIdPrefix)

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Models;
 
-use FredBradley\Cacher\Cacher;
 use FredBradley\EasyTime\EasySeconds;
 use FredBradley\TOPDesk\Facades\TOPDesk;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 abstract class BaseModel
@@ -34,10 +36,13 @@ abstract class BaseModel
         self::$model = get_called_class();
         self::$endpoint = match (self::$model) {
             Asset::class => 'assetmgmt/assets',
+            Branch::class => 'branches',
+            Location::class => 'locations',
             Operator::class => 'operators',
             OperatorGroup::class => 'operatorgroups',
             Person::class => 'persons',
-            PersonGroup::class => 'persongroups'
+            PersonGroup::class => 'persongroups',
+            Supplier::class => 'suppliers',
         };
     }
 
@@ -59,7 +64,7 @@ abstract class BaseModel
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.$variableKey.$variableValue),
             forgetCache: $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
             $result = TOPDesk::query()->get('api/'.self::$endpoint.'/', [
                 'query' => $variableKey.'=='.$variableValue,
             ])->throw()->collect()->mapInto(self::$model);
@@ -74,11 +79,12 @@ abstract class BaseModel
 
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.'id'.$id), forgetCache: $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
-            $endpoint = 'api/'.self::$endpoint.'/id/'.$id;
-            if (self::$model === Asset::class) {
-                $endpoint = 'api/'.self::$endpoint.'/'.$id;
-            }
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
+            // Some APIs use /{id} directly; others use /id/{id}
+            $noIdPrefix = [Asset::class, PersonGroup::class, Supplier::class];
+            $endpoint = in_array(self::$model, $noIdPrefix)
+                ? 'api/'.self::$endpoint.'/'.$id
+                : 'api/'.self::$endpoint.'/id/'.$id;
 
             $result = TOPDesk::query()->get($endpoint)->throw()->object();
 

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -64,12 +64,10 @@ abstract class BaseModel
             forgetCache: $forgetCache);
 
         return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
-            $result = TOPDesk::query()->get('api/'.self::$endpoint.'/', [
+            return TOPDesk::query()->get('api/'.self::$endpoint.'/', [
                 'query' => $variableKey.'=='.$variableValue,
-            ])->throw()->collect()->mapInto(self::$model);
-
-            return $result;
-        });
+            ])->throw()->collect();
+        })->mapInto(self::$model);
     }
 
     public static function findById(string $id, bool $forgetCache = false): BaseModel
@@ -78,16 +76,16 @@ abstract class BaseModel
 
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.'id'.$id), forgetCache: $forgetCache);
 
-        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
+        $data = self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
             // Some APIs use /{id} directly; others use /id/{id}
             $noIdPrefix = [Asset::class, PersonGroup::class, Supplier::class];
             $endpoint = in_array(self::$model, $noIdPrefix)
                 ? 'api/'.self::$endpoint.'/'.$id
                 : 'api/'.self::$endpoint.'/id/'.$id;
 
-            $result = TOPDesk::query()->get($endpoint)->throw()->object();
-
-            return new self::$model($result);
+            return TOPDesk::query()->get($endpoint)->throw()->object();
         });
+
+        return new self::$model($data);
     }
 }

--- a/src/Models/Branch.php
+++ b/src/Models/Branch.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Branch extends BaseModel {}
+class Branch extends BaseModel
+{
+}

--- a/src/Models/Branch.php
+++ b/src/Models/Branch.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Branch extends BaseModel
-{
-}
+class Branch extends BaseModel {}

--- a/src/Models/Branch.php
+++ b/src/Models/Branch.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Operator extends BaseModel {}
+class Branch extends BaseModel {}

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Operator extends BaseModel {}
+class Location extends BaseModel {}

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Location extends BaseModel
-{
-}
+class Location extends BaseModel {}

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Location extends BaseModel {}
+class Location extends BaseModel
+{
+}

--- a/src/Models/Operator.php
+++ b/src/Models/Operator.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Operator extends BaseModel
-{
-}
+class Operator extends BaseModel {}

--- a/src/Models/Operator.php
+++ b/src/Models/Operator.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Operator extends BaseModel {}
+class Operator extends BaseModel
+{
+}

--- a/src/Models/OperatorGroup.php
+++ b/src/Models/OperatorGroup.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class OperatorGroup extends BaseModel {}
+class OperatorGroup extends BaseModel
+{
+}

--- a/src/Models/OperatorGroup.php
+++ b/src/Models/OperatorGroup.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Models;
 
-class OperatorGroup extends BaseModel
-{
-}
+class OperatorGroup extends BaseModel {}

--- a/src/Models/OperatorGroup.php
+++ b/src/Models/OperatorGroup.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class OperatorGroup extends BaseModel
-{
-}
+class OperatorGroup extends BaseModel {}

--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Models;
 
-class Person extends BaseModel
-{
-}
+class Person extends BaseModel {}

--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Person extends BaseModel {}
+class Person extends BaseModel
+{
+}

--- a/src/Models/Person.php
+++ b/src/Models/Person.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Person extends BaseModel
-{
-}
+class Person extends BaseModel {}

--- a/src/Models/PersonGroup.php
+++ b/src/Models/PersonGroup.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class PersonGroup extends BaseModel
-{
-}
+class PersonGroup extends BaseModel {}

--- a/src/Models/PersonGroup.php
+++ b/src/Models/PersonGroup.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class PersonGroup extends BaseModel {}
+class PersonGroup extends BaseModel
+{
+}

--- a/src/Models/PersonGroup.php
+++ b/src/Models/PersonGroup.php
@@ -1,7 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Models;
 
-class PersonGroup extends BaseModel
-{
-}
+class PersonGroup extends BaseModel {}

--- a/src/Models/Supplier.php
+++ b/src/Models/Supplier.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Supplier extends BaseModel {}
+class Supplier extends BaseModel
+{
+}

--- a/src/Models/Supplier.php
+++ b/src/Models/Supplier.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Supplier extends BaseModel
-{
-}
+class Supplier extends BaseModel {}

--- a/src/Models/Supplier.php
+++ b/src/Models/Supplier.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace FredBradley\TOPDesk\Models;
 
-class Operator extends BaseModel {}
+class Supplier extends BaseModel {}

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -47,7 +47,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws \Illuminate\Http\Client\RequestException|\Illuminate\Http\Client\ConnectionException
      */
     public function get(string $uri, array $query = []): array|object
     {

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -20,8 +20,12 @@ use FredBradley\TOPDesk\Traits\OperatorStats;
 use FredBradley\TOPDesk\Traits\PersonManagement;
 use FredBradley\TOPDesk\Traits\Persons;
 use FredBradley\TOPDesk\Traits\Suppliers;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -47,7 +51,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException|\Illuminate\Http\Client\ConnectionException
+     * @throws RequestException|ConnectionException
      */
     public function get(string $uri, array $query = []): array|object
     {
@@ -55,7 +59,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function post(string $uri, array $data = []): array|object
     {
@@ -63,7 +67,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function put(string $uri, array $data = []): array|object
     {
@@ -71,7 +75,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function patch(string $uri, array $data = []): array|object
     {
@@ -79,7 +83,7 @@ class TOPDesk
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function delete(string $uri, array $data = []): array|object
     {
@@ -100,22 +104,31 @@ class TOPDesk
         return $response->throw()->object();
     }
 
+    public function setCache(): Repository
+    {
+        return Cache::store('file');
+    }
+    public static function cache(): Repository
+    {
+        return Cache::store('file');
+    }
+
     public function getArchiveReasonId(string $string): string
     {
         return $this->getArchiveReasons()->where('name', $string)->first()['id'];
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
-    public function getArchiveReasons(): \Illuminate\Support\Collection
+    public function getArchiveReasons(): Collection
     {
         return self::query()->get('api/archiving-reasons')->throw()->collect();
     }
 
     /**
      * Pattern: cache-busting helper used by traits.
-     * Forgets the entry so the subsequent Cache::remember() call misses and
+     * Forgets the entry so the subsequent self::cache()->remember() call misses and
      * re-populates — honouring both per-call $forgetCache and the global
      * ignore_cache config flag without duplicating the logic in every method.
      */

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -75,7 +75,7 @@ class TOPDesk
     }
 
     /**
-     * @throws RequestException
+     * @throws RequestException|ConnectionException
      */
     public function patch(string $uri, array $data = []): array|object
     {
@@ -83,7 +83,7 @@ class TOPDesk
     }
 
     /**
-     * @throws RequestException
+     * @throws RequestException|ConnectionException
      */
     public function delete(string $uri, array $data = []): array|object
     {
@@ -94,6 +94,7 @@ class TOPDesk
      * Pattern: HTTP 204 No Content carries no body; return an empty array rather
      * than calling ->object() which would return null and break callers expecting
      * an object. All other responses are thrown on error then decoded.
+     *
      * @throws RequestException
      */
     private function process(Response $response): array|object

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -94,6 +94,7 @@ class TOPDesk
      * Pattern: HTTP 204 No Content carries no body; return an empty array rather
      * than calling ->object() which would return null and break callers expecting
      * an object. All other responses are thrown on error then decoded.
+     * @throws RequestException
      */
     private function process(Response $response): array|object
     {
@@ -104,13 +105,9 @@ class TOPDesk
         return $response->throw()->object();
     }
 
-    public function setCache(): Repository
-    {
-        return Cache::store('file');
-    }
     public static function cache(): Repository
     {
-        return Cache::store('file');
+        return Cache::store(config('topdesk.cache_driver'));
     }
 
     public function getArchiveReasonId(string $string): string

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -1,101 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk;
 
-use FredBradley\Cacher\Cacher;
 use FredBradley\TOPDesk\Exceptions\ConfigNotFound;
 use FredBradley\TOPDesk\Traits\Assets;
+use FredBradley\TOPDesk\Traits\Branches;
 use FredBradley\TOPDesk\Traits\Changes;
 use FredBradley\TOPDesk\Traits\Counts;
+use FredBradley\TOPDesk\Traits\Departments;
+use FredBradley\TOPDesk\Traits\General;
+use FredBradley\TOPDesk\Traits\IncidentActions;
+use FredBradley\TOPDesk\Traits\IncidentLookups;
 use FredBradley\TOPDesk\Traits\Incidents;
+use FredBradley\TOPDesk\Traits\Locations;
+use FredBradley\TOPDesk\Traits\OperatorManagement;
 use FredBradley\TOPDesk\Traits\OperatorStats;
+use FredBradley\TOPDesk\Traits\PersonManagement;
 use FredBradley\TOPDesk\Traits\Persons;
-use GuzzleHttp\Client;
+use FredBradley\TOPDesk\Traits\Suppliers;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class TOPDesk
 {
-    use Assets, Changes, Counts, Incidents, OperatorStats, Persons;
+    use Assets, Branches, Changes, Counts, Departments, General,
+        IncidentActions, IncidentLookups, Incidents, Locations,
+        OperatorManagement, OperatorStats, PersonManagement, Persons, Suppliers;
 
-    private $client;
-
-    public static function query(): PendingRequest
-    {
-        return Http::topdeskAuth();
-    }
-
-    /**
-     * TOPDesk constructor.
-     *
-     * @param  string  $endpoint
-     * @param  int  $retries
-     * @param  array  $guzzleOptions
-     */
     public function __construct()
     {
-        $this->client = new Client([
-            'base_uri' => $this->endpointWithTrailingSlash(),
-            'auth' => [
-                config('topdesk.application_username'),
-                config('topdesk.application_password'),
-            ],
-        ]);
         $this->checkConfig();
     }
 
     /**
-     * Let the User know if they have forgotten to update their .env file.
-     *
-     * @throws ConfigNotFound
+     * Pattern: single authenticated entry-point for all HTTP calls.
+     * The `topdeskAuth` macro (registered in TOPDeskServiceProvider) centralises
+     * base-URL, credentials, and Accept header so no other code needs to know them.
      */
-    private function checkConfig()
+    public static function query(): PendingRequest
     {
-        foreach (config('topdesk') as $key => $config) {
-            if ($config === null) {
-                throw new ConfigNotFound("You need to set the config for env('topdesk.".$key."')", 400);
-            }
-            if ($config === '') {
-                throw new ConfigNotFound(
-                    "It seems unlikely that the env('topdesk.".$key."') should be an empty string!? I don't work with people like that!",
-                    400
-                );
-            }
-        }
-    }
-
-    /**
-     * @throws \Illuminate\Http\Client\RequestException
-     */
-    public function delete(string $uri, array $data = []): array|object
-    {
-        return $this->process($this->setupResponse()->delete($uri, $data));
-    }
-
-    /**
-     * @throws \Illuminate\Http\Client\RequestException
-     */
-    public function patch(string $uri, array $data = []): array|object
-    {
-        return $this->process($this->setupResponse()->patch($uri, $data));
-    }
-
-    /**
-     * @throws \Illuminate\Http\Client\RequestException
-     */
-    public function put(string $uri, array $data = []): array|object
-    {
-        return $this->process($this->setupResponse()->put($uri, $data));
-    }
-
-    /**
-     * @throws \Illuminate\Http\Client\RequestException
-     */
-    public function post(string $uri, array $data = []): array|object
-    {
-        return $this->process($this->setupResponse()->post($uri, $data));
+        return Http::topdeskAuth();
     }
 
     /**
@@ -103,27 +51,53 @@ class TOPDesk
      */
     public function get(string $uri, array $query = []): array|object
     {
-        return $this->process($this->setupResponse()->get($uri, $query));
+        return $this->process(self::query()->get($uri, $query));
     }
 
     /**
      * @throws \Illuminate\Http\Client\RequestException
      */
+    public function post(string $uri, array $data = []): array|object
+    {
+        return $this->process(self::query()->post($uri, $data));
+    }
+
+    /**
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function put(string $uri, array $data = []): array|object
+    {
+        return $this->process(self::query()->put($uri, $data));
+    }
+
+    /**
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function patch(string $uri, array $data = []): array|object
+    {
+        return $this->process(self::query()->patch($uri, $data));
+    }
+
+    /**
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function delete(string $uri, array $data = []): array|object
+    {
+        return $this->process(self::query()->delete($uri, $data));
+    }
+
+    /**
+     * Pattern: HTTP 204 No Content carries no body; return an empty array rather
+     * than calling ->object() which would return null and break callers expecting
+     * an object. All other responses are thrown on error then decoded.
+     */
     private function process(Response $response): array|object
     {
-        if ($response->status() === \Illuminate\Http\Response::HTTP_NO_CONTENT) {
+        if ($response->noContent()) {
             return [];
         }
 
         return $response->throw()->object();
-    }
-
-    private function setupResponse(): PendingRequest
-    {
-        return Http::acceptJson()->withBasicAuth(
-            config('topdesk.application_username'),
-            config('topdesk.application_password')
-        )->baseUrl($this->endpointWithTrailingSlash());
     }
 
     public function getArchiveReasonId(string $string): string
@@ -134,62 +108,43 @@ class TOPDesk
     /**
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function getArchiveReasons(): Collection
+    public function getArchiveReasons(): \Illuminate\Support\Collection
     {
-        return self::query()
-            ->get('api/archiving-reasons')
-            ->throw()
-            ->collect();
+        return self::query()->get('api/archiving-reasons')->throw()->collect();
     }
 
     /**
-     * Let's hold the end users hands,
-     * and if they fall at the first hurdle,
-     * we won't say a thing!
-     */
-    private function endpointWithTrailingSlash(): string
-    {
-        return rtrim(config('topdesk.endpoint'), '/\\').'/';
-    }
-
-    /**
-     * Does some repetitive lifting for us. Calculates whether we should happily
-     * rely on the Cache or to clear that cache object and fetch brand new data.
-     *
-     * It then returns the cacheKey back so the framework can use it.
-     *
-     *
-     * @throws \FredBradley\Cacher\Exceptions\FrameworkNotDetected
+     * Pattern: cache-busting helper used by traits.
+     * Forgets the entry so the subsequent Cache::remember() call misses and
+     * re-populates — honouring both per-call $forgetCache and the global
+     * ignore_cache config flag without duplicating the logic in every method.
      */
     public function setupCacheObject(string $cacheKey, bool $forgetCache): string
     {
         if ($forgetCache || config('topdesk.ignore_cache')) {
-            Cacher::forget($cacheKey);
+            Cache::forget($cacheKey);
         }
 
         return $cacheKey;
     }
 
     /**
-     * Shorthand function to create requests with JSON body and query parameters.
-     *
-     * @param  string  $uri
-     * @param  array  $json
-     * @param  bool  $decode  JSON decode response body (defaults to true).
-     * @return mixed|ResponseInterface
-     *
-     * @throws \Exception
-     *
-     * @deprecated Use specific HTTP OPTION method instead
+     * @throws ConfigNotFound
      */
-    public function request(
-        $method,
-        $uri = '',
-        array $body = [],
-        array $query = [],
-        array $options = [],
-        $decode = true
-    ) {
-        throw new \Exception('Method Deprecated. Use specific HTTP OPTION method instead.');
+    private function checkConfig(): void
+    {
+        foreach (config('topdesk') as $key => $value) {
+            if ($value === null) {
+                throw new ConfigNotFound("Config value 'topdesk.{$key}' is not set.");
+            }
+            if ($value === '') {
+                throw new ConfigNotFound("Config value 'topdesk.{$key}' must not be an empty string.");
+            }
+        }
+    }
+
+    private function endpointWithTrailingSlash(): string
+    {
+        return rtrim(config('topdesk.endpoint'), '/\\').'/';
     }
 }

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -10,6 +10,7 @@ use FredBradley\TOPDesk\Traits\Branches;
 use FredBradley\TOPDesk\Traits\Changes;
 use FredBradley\TOPDesk\Traits\Counts;
 use FredBradley\TOPDesk\Traits\Departments;
+use FredBradley\TOPDesk\Traits\DeprecatedMethods;
 use FredBradley\TOPDesk\Traits\General;
 use FredBradley\TOPDesk\Traits\IncidentActions;
 use FredBradley\TOPDesk\Traits\IncidentLookups;
@@ -31,7 +32,7 @@ use Illuminate\Support\Facades\Http;
 
 class TOPDesk
 {
-    use Assets, Branches, Changes, Counts, Departments, General,
+    use Assets, Branches, Changes, Counts, Departments, DeprecatedMethods, General,
         IncidentActions, IncidentLookups, Incidents, Locations,
         OperatorManagement, OperatorStats, PersonManagement, Persons, Suppliers;
 
@@ -154,10 +155,5 @@ class TOPDesk
                 throw new ConfigNotFound("Config value 'topdesk.{$key}' must not be an empty string.");
             }
         }
-    }
-
-    private function endpointWithTrailingSlash(): string
-    {
-        return rtrim(config('topdesk.endpoint'), '/\\').'/';
     }
 }

--- a/src/TOPDesk.php
+++ b/src/TOPDesk.php
@@ -53,7 +53,7 @@ class TOPDesk
     /**
      * @throws RequestException|ConnectionException
      */
-    public function get(string $uri, array $query = []): array|object
+    public function get(string $uri, array $query = []): mixed
     {
         return $this->process(self::query()->get($uri, $query));
     }
@@ -61,7 +61,7 @@ class TOPDesk
     /**
      * @throws RequestException
      */
-    public function post(string $uri, array $data = []): array|object
+    public function post(string $uri, array $data = []): mixed
     {
         return $this->process(self::query()->post($uri, $data));
     }
@@ -69,7 +69,7 @@ class TOPDesk
     /**
      * @throws RequestException
      */
-    public function put(string $uri, array $data = []): array|object
+    public function put(string $uri, array $data = []): mixed
     {
         return $this->process(self::query()->put($uri, $data));
     }
@@ -77,7 +77,7 @@ class TOPDesk
     /**
      * @throws RequestException|ConnectionException
      */
-    public function patch(string $uri, array $data = []): array|object
+    public function patch(string $uri, array $data = []): mixed
     {
         return $this->process(self::query()->patch($uri, $data));
     }
@@ -85,7 +85,7 @@ class TOPDesk
     /**
      * @throws RequestException|ConnectionException
      */
-    public function delete(string $uri, array $data = []): array|object
+    public function delete(string $uri, array $data = []): mixed
     {
         return $this->process(self::query()->delete($uri, $data));
     }
@@ -94,10 +94,12 @@ class TOPDesk
      * Pattern: HTTP 204 No Content carries no body; return an empty array rather
      * than calling ->object() which would return null and break callers expecting
      * an object. All other responses are thrown on error then decoded.
+     * Note: json_decode() can return any PHP type (int, string, bool, …) for
+     * valid scalar JSON, so the return type is mixed rather than array|object.
      *
      * @throws RequestException
      */
-    private function process(Response $response): array|object
+    private function process(Response $response): mixed
     {
         if ($response->noContent()) {
             return [];

--- a/src/TOPDeskServiceProvider.php
+++ b/src/TOPDeskServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk;
 
 use Illuminate\Http\Client\PendingRequest;
@@ -7,87 +9,48 @@ use Illuminate\Support\ServiceProvider;
 
 class TOPDeskServiceProvider extends ServiceProvider
 {
-    /**
-     * Perform post-registration booting of services.
-     *
-     * @return void
-     */
-    public function boot()
+    public function boot(): void
     {
-        PendingRequest::macro('topdeskAuth', function () {
-            // Useful sanitization technique
-            $endpointWithTrailingSlash = rtrim(config('topdesk.endpoint'), '/\\').'/';
-
-            return PendingRequest::withBasicAuth(
-                config('topdesk.application_username'),
-                config('topdesk.application_password')
-            )->baseUrl($endpointWithTrailingSlash);
+        /*
+         * Pattern: Http::macro() extends Laravel's HTTP client with a named,
+         * pre-configured PendingRequest. All credential and base-URL knowledge
+         * lives here — nothing else in the package needs to know how auth works.
+         *
+         * The closure is bound to the PendingRequest instance at call time,
+         * so $this refers to the PendingRequest being built, not the service provider.
+         * This is why withBasicAuth() and baseUrl() are called on $this rather
+         * than as static calls on PendingRequest.
+         */
+        PendingRequest::macro('topdeskAuth', function (): PendingRequest {
+            return $this->acceptJson()
+                ->withBasicAuth(
+                    config('topdesk.application_username'),
+                    config('topdesk.application_password')
+                )
+                ->baseUrl(rtrim(config('topdesk.endpoint'), '/\\').'/');
         });
 
-        // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'fredbradley');
-        // $this->loadViewsFrom(__DIR__.'/../resources/views', 'fredbradley');
-        // $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        // $this->loadRoutesFrom(__DIR__.'/routes.php');
-
-        // Publishing is only necessary when using the CLI.
         if ($this->app->runningInConsole()) {
-            $this->bootForConsole();
+            $this->publishes([
+                __DIR__.'/../config/topdesk.php' => config_path('topdesk.php'),
+            ], 'topdesk.config');
         }
     }
 
-    /**
-     * Register any package services.
-     *
-     * @return void
-     */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/topdesk.php', 'topdesk');
 
-        // Register the service the package provides.
-        $this->app->singleton('topdesk', function ($app) {
-            return new TOPDesk;
-        });
+        /*
+         * Pattern: singleton registration binds the class to the container
+         * under a string key. The Facade's getFacadeAccessor() resolves it
+         * by that key, so neither the Facade nor callers need to import TOPDesk.
+         */
+        $this->app->singleton('topdesk', fn () => new TOPDesk);
     }
 
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
+    public function provides(): array
     {
         return ['topdesk'];
-    }
-
-    /**
-     * Console-specific booting.
-     *
-     * @return void
-     */
-    protected function bootForConsole()
-    {
-        // Publishing the configuration file.
-        $this->publishes([
-            __DIR__.'/../config/topdesk.php' => config_path('topdesk.php'),
-        ], 'topdesk.config');
-
-        // Publishing the views.
-        /*$this->publishes([
-            __DIR__.'/../resources/views' => base_path('resources/views/vendor/fredbradley'),
-        ], 'topdesk.views');*/
-
-        // Publishing assets.
-        /*$this->publishes([
-            __DIR__.'/../resources/assets' => public_path('vendor/fredbradley'),
-        ], 'topdesk.views');*/
-
-        // Publishing the translation files.
-        /*$this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/fredbradley'),
-        ], 'topdesk.views');*/
-
-        // Registering package commands.
-        $this->commands([]);
     }
 }

--- a/src/Traits/Assets.php
+++ b/src/Traits/Assets.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
+use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
 /**
@@ -14,12 +18,14 @@ trait Assets
     {
         $cacheKey = $this->setupCacheObject('assetTemplateId_'.$name, $forgetCache);
 
-        return Cache::rememberForever($cacheKey, function () use ($name) {
+        // Pattern: Cache::remember with a long but finite TTL rather than rememberForever.
+        // rememberForever entries are never evicted, which causes stale IDs to survive
+        // cache flushes. A 30-day TTL is effectively permanent for this data but
+        // respects the $forgetCache / ignore_cache flags via setupCacheObject().
+        return Cache::remember($cacheKey, EasySeconds::days(30), function () use ($name) {
             $return = self::query()->get('api/assetmgmt/templates')->throw()->collect();
 
-            $result = collect($return['dataSet']);
-
-            return $result->where('text', '=', $name)->first()['id'];
+            return collect($return['dataSet'])->where('text', '=', $name)->first()['id'];
         });
     }
 
@@ -64,5 +70,122 @@ trait Assets
     public function createAssetByTemplateId(string $templateId, array $data)
     {
         return $this->post('api/assetmgmt/assets/templateId/'.$templateId, $data);
+    }
+
+    public function getAsset(string $assetId): object
+    {
+        return $this->get('api/assetmgmt/assets/'.$assetId);
+    }
+
+    /**
+     * Note: the Asset Management API uses POST (not PATCH) for field-level updates on individual assets.
+     */
+    public function updateAsset(string $assetId, array $data): array|object
+    {
+        return $this->post('api/assetmgmt/assets/'.$assetId, $data);
+    }
+
+    public function archiveAsset(string $assetId): array|object
+    {
+        return $this->post('api/assetmgmt/assets/'.$assetId.'/archive', []);
+    }
+
+    public function unarchiveAsset(string $assetId): array|object
+    {
+        return $this->post('api/assetmgmt/assets/'.$assetId.'/unarchive', []);
+    }
+
+    public function copyAsset(string $assetId): array|object
+    {
+        return $this->post('api/assetmgmt/assets/'.$assetId.'/copy', []);
+    }
+
+    /**
+     * @param  array  $assetIds  Array of asset ID strings to delete
+     */
+    public function deleteAssets(array $assetIds): array|object
+    {
+        return $this->post('api/assetmgmt/assets/delete', ['assetIds' => $assetIds]);
+    }
+
+    // === Assignments ===
+
+    public function getAssetAssignments(string $assetId): array|object
+    {
+        return $this->get('api/assetmgmt/assets/'.$assetId.'/assignments');
+    }
+
+    /**
+     * @param  array  $data  Keys: branch{id}, location{id}, person{id}, personGroup{id}
+     */
+    public function addAssetAssignment(string $assetId, array $data): array|object
+    {
+        return $this->put('api/assetmgmt/assets/'.$assetId.'/assignments', $data);
+    }
+
+    public function removeAssetAssignment(string $assetId, string $linkId): array|object
+    {
+        return $this->delete('api/assetmgmt/assets/'.$assetId.'/assignments/'.$linkId);
+    }
+
+    // === Asset Links ===
+
+    /**
+     * @param  array  $query  Keys: sourceId, targetId, capabilityId
+     */
+    public function getAssetLinks(array $query = []): array|object
+    {
+        return $this->get('api/assetmgmt/assetLinks', $query);
+    }
+
+    /**
+     * @param  array  $data  Keys: sourceId, targetId, capabilityId
+     */
+    public function createAssetLink(array $data): array|object
+    {
+        return $this->post('api/assetmgmt/assetLinks', $data);
+    }
+
+    public function deleteAssetLink(string $relationId): array|object
+    {
+        return $this->delete('api/assetmgmt/assetLinks/'.$relationId);
+    }
+
+    // === Lookups ===
+
+    public function getAssetStatuses(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('asset_statuses', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/assetStatuses')->throw()->collect());
+    }
+
+    public function getCardTypes(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('card_types', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/cardTypes')->throw()->collect());
+    }
+
+    /**
+     * @param  array  $options  Keys: archived, searchTerm, resourceCategory
+     */
+    public function getAssetTemplates(array $options = [], bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('asset_templates', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/templates', $options)->throw()->collect());
+    }
+
+    // === Asset History ===
+
+    public function getAssetHistory(string $assetId): array|object
+    {
+        return $this->get('api/assetmgmt/assets/'.$assetId.'/history/pastItems');
+    }
+
+    public function getAssetCurrentItems(string $assetId): array|object
+    {
+        return $this->get('api/assetmgmt/assets/'.$assetId.'/history/currentItems');
     }
 }

--- a/src/Traits/Assets.php
+++ b/src/Traits/Assets.php
@@ -35,7 +35,7 @@ trait Assets
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function assignIncidentToAsset(string $assetID, string $incidentID): object
     {

--- a/src/Traits/Assets.php
+++ b/src/Traits/Assets.php
@@ -23,9 +23,9 @@ trait Assets
         // cache flushes. A 30-day TTL is effectively permanent for this data but
         // respects the $forgetCache / ignore_cache flags via setupCacheObject().
         return self::cache()->remember($cacheKey, EasySeconds::days(30), function () use ($name) {
-            $return = self::query()->get('api/assetmgmt/templates')->throw()->collect();
+            $return = self::query()->get('api/assetmgmt/cardTypes')->throw()->collect();
 
-            return collect($return['dataSet'])->where('text', '=', $name)->first()['id'];
+            return collect($return["cardTypes"])->where("displayName", "=", $name)->first()["key"];
         });
     }
 

--- a/src/Traits/Assets.php
+++ b/src/Traits/Assets.php
@@ -22,7 +22,7 @@ trait Assets
         // rememberForever entries are never evicted, which causes stale IDs to survive
         // cache flushes. A 30-day TTL is effectively permanent for this data but
         // respects the $forgetCache / ignore_cache flags via setupCacheObject().
-        return Cache::remember($cacheKey, EasySeconds::days(30), function () use ($name) {
+        return self::cache()->remember($cacheKey, EasySeconds::days(30), function () use ($name) {
             $return = self::query()->get('api/assetmgmt/templates')->throw()->collect();
 
             return collect($return['dataSet'])->where('text', '=', $name)->first()['id'];
@@ -157,14 +157,14 @@ trait Assets
     {
         $cacheKey = $this->setupCacheObject('asset_statuses', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/assetStatuses')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/assetStatuses')->throw()->collect());
     }
 
     public function getCardTypes(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('card_types', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/cardTypes')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/cardTypes')->throw()->collect());
     }
 
     /**
@@ -174,7 +174,7 @@ trait Assets
     {
         $cacheKey = $this->setupCacheObject('asset_templates', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/templates', $options)->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/assetmgmt/templates', $options)->throw()->collect());
     }
 
     // === Asset History ===

--- a/src/Traits/Branches.php
+++ b/src/Traits/Branches.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait Branches
 {

--- a/src/Traits/Branches.php
+++ b/src/Traits/Branches.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait Branches
+{
+    /**
+     * @param  array  $query  Supports FIQL via 'query' key and field selection via '$fields'
+     */
+    public function getBranches(array $query = []): Collection
+    {
+        return self::query()->get('api/branches', $query)->throw()->collect();
+    }
+
+    public function getBranch(string $id): object
+    {
+        return $this->get('api/branches/id/'.$id);
+    }
+
+    /**
+     * @param  array  $data  Keys: name, specification, clientReferenceNumber, timeZone, extraA, extraB,
+     *                       phone, fax, email, website, branchType, headBranch, address, postalAddress, etc.
+     */
+    public function createBranch(array $data): object
+    {
+        return $this->post('api/branches', $data);
+    }
+
+    public function updateBranch(string $id, array $data): object
+    {
+        return $this->patch('api/branches/id/'.$id, $data);
+    }
+
+    public function archiveBranch(string $id): array|object
+    {
+        return $this->patch('api/branches/id/'.$id.'/archive');
+    }
+
+    public function unarchiveBranch(string $id): array|object
+    {
+        return $this->patch('api/branches/id/'.$id.'/unarchive');
+    }
+
+    /**
+     * @param  array  $options  Keys: $top (max 10000), name (prefix filter), archived
+     */
+    public function getBranchLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/branches/lookup', $options)->throw()->collect();
+    }
+
+    public function getBranchId(string $name, bool $forgetCache = false): string
+    {
+        $cacheKey = $this->setupCacheObject('branch_id_'.md5($name), $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::hours(1), function () use ($name) {
+            return self::query()->get('api/branches/lookup', ['name' => $name])->throw()->collect()->first()['id'];
+        });
+    }
+
+    public function getBranchDesignations(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('branch_designations', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/designations')->throw()->collect());
+    }
+
+    public function getBranchBuildingLevels(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('branch_building_levels', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/buildingLevels')->throw()->collect());
+    }
+
+    public function getBranchAttachments(string $id, array $options = []): Collection
+    {
+        return self::query()->get('api/branches/id/'.$id.'/attachments', $options)->throw()->collect();
+    }
+
+    public function deleteBranchAttachment(string $id, string $attachmentId): array|object
+    {
+        return $this->delete('api/branches/id/'.$id.'/attachments/'.$attachmentId);
+    }
+}

--- a/src/Traits/Branches.php
+++ b/src/Traits/Branches.php
@@ -59,7 +59,7 @@ trait Branches
     {
         $cacheKey = $this->setupCacheObject('branch_id_'.md5($name), $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::hours(1), function () use ($name) {
+        return self::cache()->remember($cacheKey, EasySeconds::hours(1), function () use ($name) {
             return self::query()->get('api/branches/lookup', ['name' => $name])->throw()->collect()->first()['id'];
         });
     }
@@ -68,14 +68,14 @@ trait Branches
     {
         $cacheKey = $this->setupCacheObject('branch_designations', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/designations')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/designations')->throw()->collect());
     }
 
     public function getBranchBuildingLevels(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('branch_building_levels', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/buildingLevels')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/branches/buildingLevels')->throw()->collect());
     }
 
     public function getBranchAttachments(string $id, array $options = []): Collection

--- a/src/Traits/Changes.php
+++ b/src/Traits/Changes.php
@@ -19,7 +19,7 @@ trait Changes
 
     public function allOpenChangeActivities(): Collection
     {
-        return Cache::remember('operatorChangeActivites', EasySeconds::minutes(10), function () {
+        return self::cache()->remember('operatorChangeActivites', EasySeconds::minutes(10), function () {
             return collect($this->get('api/operatorChangeActivities', [
                 'open' => 'true',
                 'sort' => 'plannedFinalDate',
@@ -33,7 +33,7 @@ trait Changes
     {
         $operatorId = $this->getOperatorGroupId($operatorGroupName);
 
-        return Cache::remember(
+        return self::cache()->remember(
             'unassignedWaitingChangeActivities_'.$operatorId,
             EasySeconds::minutes(10),
             fn () => collect($this->get('api/operatorChangeActivities', [
@@ -53,7 +53,7 @@ trait Changes
 
     public function resolvedChangeActivitiesByOperatorIdByTime(string $operatorId, string $timeString = 'Week'): Collection
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'resolvedChangeActivitesByOperatorAndTime_'.$operatorId.'_'.$timeString,
             EasySeconds::hours(1),
             fn () => collect($this->get('api/operatorChangeActivities', [
@@ -67,7 +67,7 @@ trait Changes
 
     public function waitingChangeActivitiesByOperatorId(string $operatorId): Collection
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'waitingChangeActivitiesByOperatorId_'.$operatorId,
             EasySeconds::hours(1),
             fn () => collect($this->get('api/operatorChangeActivities', [

--- a/src/Traits/Changes.php
+++ b/src/Traits/Changes.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait Changes
 {

--- a/src/Traits/Changes.php
+++ b/src/Traits/Changes.php
@@ -1,80 +1,82 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
-use FredBradley\Cacher\Cacher;
 use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 
 trait Changes
 {
-    public function allOpenChangeActivities(): array
+    /*
+     * Pattern: return Collection instead of array.
+     * The TOPdesk API wraps paginated results in a {results: [...]} envelope.
+     * Wrapping in collect() gives callers first(), filter(), map(), etc. for free
+     * and makes the return type explicit rather than leaking the API's envelope shape.
+     */
+
+    public function allOpenChangeActivities(): Collection
     {
-        return Cacher::remember('operatorChangeActivites', EasySeconds::minutes(10), function () {
-            return $this->get('api/operatorChangeActivities', [
+        return Cache::remember('operatorChangeActivites', EasySeconds::minutes(10), function () {
+            return collect($this->get('api/operatorChangeActivities', [
                 'open' => 'true',
                 'sort' => 'plannedFinalDate',
                 'blocked' => 'false',
                 'archived' => 'false',
-            ])->results;
+            ])->results ?? []);
         });
     }
 
-    public function unassignedWaitingChangeActivities(string $operatorGroupName = 'I.T. Services'): array
+    public function unassignedWaitingChangeActivities(string $operatorGroupName = 'I.T. Services'): Collection
     {
         $operatorId = $this->getOperatorGroupId($operatorGroupName);
 
-        return Cacher::remember(
+        return Cache::remember(
             'unassignedWaitingChangeActivities_'.$operatorId,
             EasySeconds::minutes(10),
-            function () use ($operatorId) {
-                return $this->get('api/operatorChangeActivities', [
-                    'open' => 'true',
-                    'sort' => 'plannedFinalDate',
-                    'blocked' => 'false',
-                    'archived' => 'false',
-                    'operator' => $operatorId,
-                ])->results;
-            }
+            fn () => collect($this->get('api/operatorChangeActivities', [
+                'open' => 'true',
+                'sort' => 'plannedFinalDate',
+                'blocked' => 'false',
+                'archived' => 'false',
+                'operator' => $operatorId,
+            ])->results ?? [])
         );
     }
 
-    public function waitingChangeActivitiesByUsername(string $username): array
+    public function waitingChangeActivitiesByUsername(string $username): Collection
     {
-        $operatorId = $this->getOperatorByUsername($username)->id;
-
-        return $this->waitingChangeActivitiesByOperatorId($operatorId);
+        return $this->waitingChangeActivitiesByOperatorId($this->getOperatorByUsername($username)->id);
     }
 
-    public function resolvedChangeActivitiesByOperatorIdByTime(string $operatorId, string $timeString = 'Week'): array
+    public function resolvedChangeActivitiesByOperatorIdByTime(string $operatorId, string $timeString = 'Week'): Collection
     {
-        return Cacher::remember(
+        return Cache::remember(
             'resolvedChangeActivitesByOperatorAndTime_'.$operatorId.'_'.$timeString,
             EasySeconds::hours(1),
-            function () use ($operatorId, $timeString) {
-                return $this->get('api/operatorChangeActivities', [
-                    'open' => 'false',
-                    'operator' => $operatorId,
-                    'pageSize' => 1000,
-                    'finalDateAfter' => now()->startOf($timeString)->format('Y-m-d'),
-                ])->results;
-            }
+            fn () => collect($this->get('api/operatorChangeActivities', [
+                'open' => 'false',
+                'operator' => $operatorId,
+                'pageSize' => 1000,
+                'finalDateAfter' => now()->startOf($timeString)->format('Y-m-d'),
+            ])->results ?? [])
         );
     }
 
-    public function waitingChangeActivitiesByOperatorId(string $operatorId): array
+    public function waitingChangeActivitiesByOperatorId(string $operatorId): Collection
     {
-        return Cacher::remember(
+        return Cache::remember(
             'waitingChangeActivitiesByOperatorId_'.$operatorId,
             EasySeconds::hours(1),
-            function () use ($operatorId) {
-                return $this->get('api/operatorChangeActivities', [
-                    'open' => 'true',
-                    'sort' => 'plannedFinalDate',
-                    'blocked' => 'false',
-                    'archived' => 'false',
-                    'operator' => $operatorId,
-                ])->results;
-            }
+            fn () => collect($this->get('api/operatorChangeActivities', [
+                'open' => 'true',
+                'sort' => 'plannedFinalDate',
+                'blocked' => 'false',
+                'archived' => 'false',
+                'operator' => $operatorId,
+            ])->results ?? [])
         );
     }
 }

--- a/src/Traits/Counts.php
+++ b/src/Traits/Counts.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
-use FredBradley\Cacher\Cacher;
 use FredBradley\EasyTime\EasySeconds;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\TransferStats;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 trait Counts
@@ -14,7 +14,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(15), function () use ($operatorGroupName) {
+        return Cache::remember($cacheKey, EasySeconds::minutes(15), function () use ($operatorGroupName) {
             return $this->getNumIncidents('operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';creationDate=gt='.now()->startOfDay()->toIso8601String());
         });
     }
@@ -23,10 +23,8 @@ trait Counts
     {
         $cacheKey = $this->setupCacheObject('openTickets_'.$operatorGroupName, $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
-            $fiql = 'operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';closed==false';
-
-            return $this->getNumIncidents($fiql);
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+            return $this->getNumIncidents('operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';closed==false');
         });
     }
 
@@ -34,7 +32,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
             return $this->getNumIncidents('targetDate=lt='.now()->endOfWeek()->toIso8601String().';closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName));
         });
     }
@@ -43,7 +41,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
             return $this->getNumIncidents('targetDate=gt='.now()->toIso8601String().';closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName));
         });
     }
@@ -52,65 +50,24 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$processingStatusId.$operatorGroupName);
 
-        return Cacher::remember(
-            $cacheKey,
-            EasySeconds::minutes(5),
-            function () use ($processingStatusId, $operatorGroupName) {
-                return $this->getNumIncidents('closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';processingStatus.id=='.$processingStatusId);
-            }
-        );
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), fn () => $this->getNumIncidents(
+            'closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';processingStatus.id=='.$processingStatusId
+        ));
     }
 
-    private function convertArrayMergeToQueryString(array $firstArray, array $mergeFrom): string
-    {
-        $str = '';
-        foreach ([$firstArray, $mergeFrom] as $array) {
-            foreach ($array as $key => $value) {
-                if (is_array($value)) {
-                    foreach ($value as $subvalue) {
-                        $str .= $key.'='.$subvalue.'&';
-                    }
-                } else {
-                    $str .= $key.'='.$value.'&';
-                }
-            }
-        }
-
-        return $str;
-    }
-
+    /**
+     * Pattern: fetch only the `id` field and let the API paginate to 10 000 so
+     * we keep the response payload small when we only care about the count.
+     */
     public function getNumIncidents(string $fiql, array $options = []): int
     {
         $response = $this->get('api/incidents', array_merge([
-            'pageSize' => 10000, // the maximum
-            'fields' => 'id', // limit it right down if we only care about numbers
+            'pageSize' => 10000,
+            'fields' => 'id',
             'query' => $fiql,
         ], $options));
 
         return collect($response)->count();
-    }
-
-    public function getIncidents(array $options = []): array
-    {
-        try {
-            $response = $this->client->request('GET', 'api/incidents', [
-                'query' => $this->convertArrayMergeToQueryString([
-                    'start' => 0,
-                    'page_size' => 10000,
-                ], $options),
-                'on_stats' => function (TransferStats $stats) use (&$url) {
-                    $url = $stats->getEffectiveUri();
-                },
-            ]);
-
-            if ($response->getStatusCode() === 204) {
-                return [];
-            }
-        } catch (ConnectException $exception) {
-            return false;
-        }
-
-        return json_decode((string) $response->getBody(), false);
     }
 
     /**
@@ -123,26 +80,19 @@ trait Counts
 
     public function countClosedTicketsByTime(string $operatorId, string $timeString = 'week'): int
     {
-        return Cacher::remember(
+        return Cache::remember(
             'incidentsResolvedByOperatorAndTime_'.$operatorId.$timeString,
             EasySeconds::minutes(5),
-            function () use ($operatorId, $timeString) {
-                return $this->getNumIncidents('operator.id=='.$operatorId.';closed==true;closedDate=gt='.now()->startOf($timeString)->toIso8601String());
-            }
+            fn () => $this->getNumIncidents('operator.id=='.$operatorId.';closed==true;closedDate=gt='.now()->startOf($timeString)->toIso8601String())
         );
     }
 
-    /**
-     * @return mixed
-     */
     public function countOpenTicketsByOperator(string $operatorId): int
     {
-        $incidents = Cacher::remember(
+        $incidents = Cache::remember(
             'countOpenTicketsByOperator_'.$operatorId,
             EasySeconds::minutes(5),
-            function () use ($operatorId) {
-                return $this->getNumIncidents('operator.id=='.$operatorId.';closed==false');
-            }
+            fn () => $this->getNumIncidents('operator.id=='.$operatorId.';closed==false')
         );
 
         return $incidents + $this->countWaitingChangeActivitiesByOperatorId($operatorId);
@@ -150,43 +100,42 @@ trait Counts
 
     public function countActiveTicketsbyOperator(string $operatorId): int
     {
-        return Cacher::remember(
+        return Cache::remember(
             'countActiveIncidentsByOperatorID_'.$operatorId,
             EasySeconds::minutes(5),
-            function () use ($operatorId) {
-                return $this->getNumIncidents('operator.id=='.$operatorId.';closed==false;processingStatus.id=in=('.$this->getProcessingStatusId('Logged').','.$this->getProcessingStatusId('In progress').','.$this->getProcessingStatusId('Updated by user').')');
-            }
+            fn () => $this->getNumIncidents(
+                'operator.id=='.$operatorId.';closed==false;processingStatus.id=in=('
+                .$this->getProcessingStatusId('Logged').','
+                .$this->getProcessingStatusId('In progress').','
+                .$this->getProcessingStatusId('Updated by user').')'
+            )
         );
     }
 
     public function countWaitingChangeActivitiesByOperatorId(string $operatorId): int
     {
-        return Cacher::remember(
+        return Cache::remember(
             'countWaitingChangeActivitiesByOperator_'.$operatorId,
             EasySeconds::minutes(5),
-            function () use ($operatorId) {
-                return count($this->waitingChangeActivitiesByOperatorId($operatorId));
-            }
+            fn () => count($this->waitingChangeActivitiesByOperatorId($operatorId))
         );
     }
 
     public function countTicketsByStatus(string $statusName, string $operatorGroup = 'I.T. Services'): int
     {
-        return Cacher::remember(
+        return Cache::remember(
             'countTicketsByStatus_'.$statusName,
             EasySeconds::minutes(5),
-            function () use ($statusName, $operatorGroup) {
-                $statusId = $this->getProcessingStatusId($statusName);
-
-                return $this->countByProcessingStatusId($statusId, $operatorGroup);
-            }
+            fn () => $this->countByProcessingStatusId($this->getProcessingStatusId($statusName), $operatorGroup)
         );
     }
 
     public function countUnassignedTickets(string $operatorGroup = 'I.T. Services'): int
     {
-        return Cacher::remember('countUnassignedITTickets'.$operatorGroup, EasySeconds::minutes(5), function () use ($operatorGroup) {
-            return $this->getNumIncidents('operator.id=='.$this->getOperatorGroupId($operatorGroup).';closed==false');
-        });
+        return Cache::remember(
+            'countUnassignedITTickets'.$operatorGroup,
+            EasySeconds::minutes(5),
+            fn () => $this->getNumIncidents('operator.id=='.$this->getOperatorGroupId($operatorGroup).';closed==false')
+        );
     }
 }

--- a/src/Traits/Counts.php
+++ b/src/Traits/Counts.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 trait Counts

--- a/src/Traits/Counts.php
+++ b/src/Traits/Counts.php
@@ -14,7 +14,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(15), function () use ($operatorGroupName) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(15), function () use ($operatorGroupName) {
             return $this->getNumIncidents('operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';creationDate=gt='.now()->startOfDay()->toIso8601String());
         });
     }
@@ -23,7 +23,7 @@ trait Counts
     {
         $cacheKey = $this->setupCacheObject('openTickets_'.$operatorGroupName, $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
             return $this->getNumIncidents('operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';closed==false');
         });
     }
@@ -32,7 +32,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
             return $this->getNumIncidents('targetDate=lt='.now()->endOfWeek()->toIso8601String().';closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName));
         });
     }
@@ -41,7 +41,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$operatorGroupName);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupName) {
             return $this->getNumIncidents('targetDate=gt='.now()->toIso8601String().';closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName));
         });
     }
@@ -50,7 +50,7 @@ trait Counts
     {
         $cacheKey = Str::slug(__METHOD__.$processingStatusId.$operatorGroupName);
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), fn () => $this->getNumIncidents(
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), fn () => $this->getNumIncidents(
             'closed==false;operatorGroup.id=='.$this->getOperatorGroupId($operatorGroupName).';processingStatus.id=='.$processingStatusId
         ));
     }
@@ -80,7 +80,7 @@ trait Counts
 
     public function countClosedTicketsByTime(string $operatorId, string $timeString = 'week'): int
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'incidentsResolvedByOperatorAndTime_'.$operatorId.$timeString,
             EasySeconds::minutes(5),
             fn () => $this->getNumIncidents('operator.id=='.$operatorId.';closed==true;closedDate=gt='.now()->startOf($timeString)->toIso8601String())
@@ -89,7 +89,7 @@ trait Counts
 
     public function countOpenTicketsByOperator(string $operatorId): int
     {
-        $incidents = Cache::remember(
+        $incidents = self::cache()->remember(
             'countOpenTicketsByOperator_'.$operatorId,
             EasySeconds::minutes(5),
             fn () => $this->getNumIncidents('operator.id=='.$operatorId.';closed==false')
@@ -100,7 +100,7 @@ trait Counts
 
     public function countActiveTicketsbyOperator(string $operatorId): int
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'countActiveIncidentsByOperatorID_'.$operatorId,
             EasySeconds::minutes(5),
             fn () => $this->getNumIncidents(
@@ -114,7 +114,7 @@ trait Counts
 
     public function countWaitingChangeActivitiesByOperatorId(string $operatorId): int
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'countWaitingChangeActivitiesByOperator_'.$operatorId,
             EasySeconds::minutes(5),
             fn () => count($this->waitingChangeActivitiesByOperatorId($operatorId))
@@ -123,7 +123,7 @@ trait Counts
 
     public function countTicketsByStatus(string $statusName, string $operatorGroup = 'I.T. Services'): int
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'countTicketsByStatus_'.$statusName,
             EasySeconds::minutes(5),
             fn () => $this->countByProcessingStatusId($this->getProcessingStatusId($statusName), $operatorGroup)
@@ -132,7 +132,7 @@ trait Counts
 
     public function countUnassignedTickets(string $operatorGroup = 'I.T. Services'): int
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'countUnassignedITTickets'.$operatorGroup,
             EasySeconds::minutes(5),
             fn () => $this->getNumIncidents('operator.id=='.$this->getOperatorGroupId($operatorGroup).';closed==false')

--- a/src/Traits/Departments.php
+++ b/src/Traits/Departments.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use Illuminate\Support\Collection;
+
+trait Departments
+{
+    /**
+     * @param  array  $query  Keys: external_link_id, external_link_type
+     */
+    public function getDepartments(array $query = []): Collection
+    {
+        return self::query()->get('api/departments', $query)->throw()->collect();
+    }
+
+    public function createDepartment(string $name): object
+    {
+        return $this->post('api/departments', ['name' => $name]);
+    }
+
+    public function updateDepartment(string $id, string $name): object
+    {
+        return $this->patch('api/departments/id/'.$id, ['name' => $name]);
+    }
+
+    public function deleteDepartment(string $id): array|object
+    {
+        return $this->delete('api/departments/id/'.$id);
+    }
+
+    public function archiveDepartment(string $id): array|object
+    {
+        return $this->patch('api/departments/id/'.$id.'/archive');
+    }
+
+    public function unarchiveDepartment(string $id): array|object
+    {
+        return $this->patch('api/departments/id/'.$id.'/unarchive');
+    }
+}

--- a/src/Traits/DeprecatedMethods.php
+++ b/src/Traits/DeprecatedMethods.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
 trait DeprecatedMethods

--- a/src/Traits/General.php
+++ b/src/Traits/General.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait General
 {

--- a/src/Traits/General.php
+++ b/src/Traits/General.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait General
+{
+    public function getApiVersion(): string
+    {
+        return $this->get('api/version')->version;
+    }
+
+    public function getProductVersion(): object
+    {
+        return $this->get('api/productVersion');
+    }
+
+    /**
+     * @param  string  $index  Currently only 'incidents' is supported
+     */
+    public function search(string $query, string $index = 'incidents', int $start = 0): Collection
+    {
+        $response = $this->get('api/search', ['query' => $query, 'index' => $index, 'start' => $start]);
+
+        return collect($response->results ?? []);
+    }
+
+    /**
+     * @param  array  $options  Keys: $top, name (prefix filter), archived
+     */
+    public function getServiceWindows(array $options = [], bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('service_windows', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/serviceWindow/lookup/', $options)->throw()->collect());
+    }
+
+    public function getServiceWindow(string $id): object
+    {
+        return $this->get('api/serviceWindow/lookup/'.$id);
+    }
+
+    public function getEmail(string $id): object
+    {
+        return $this->get('api/emails/id/'.$id);
+    }
+
+    public function deleteEmail(string $id): array|object
+    {
+        return $this->delete('api/emails/id/'.$id);
+    }
+
+    public function getCountries(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('countries', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/countries')->throw()->collect());
+    }
+
+    public function getLanguages(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('languages', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/languages')->throw()->collect());
+    }
+}

--- a/src/Traits/General.php
+++ b/src/Traits/General.php
@@ -37,7 +37,7 @@ trait General
     {
         $cacheKey = $this->setupCacheObject('service_windows', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/serviceWindow/lookup/', $options)->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/serviceWindow/lookup/', $options)->throw()->collect());
     }
 
     public function getServiceWindow(string $id): object
@@ -59,13 +59,13 @@ trait General
     {
         $cacheKey = $this->setupCacheObject('countries', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/countries')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/countries')->throw()->collect());
     }
 
     public function getLanguages(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('languages', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/languages')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(4), fn () => self::query()->get('api/languages')->throw()->collect());
     }
 }

--- a/src/Traits/IncidentActions.php
+++ b/src/Traits/IncidentActions.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use Illuminate\Support\Collection;
+
+trait IncidentActions
+{
+    // === Progress Trail ===
+
+    public function getProgressTrail(string $incidentId, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/id/'.$incidentId.'/progresstrail', $options));
+    }
+
+    public function getProgressTrailByNumber(string $number, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/number/'.$number.'/progresstrail', $options));
+    }
+
+    public function getProgressTrailCount(string $incidentId): int
+    {
+        return (int) $this->get('api/incidents/id/'.$incidentId.'/progresstrail/count');
+    }
+
+    public function getProgressTrailCountByNumber(string $number): int
+    {
+        return (int) $this->get('api/incidents/number/'.$number.'/progresstrail/count');
+    }
+
+    // === Actions ===
+
+    public function getIncidentActions(string $incidentId, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/id/'.$incidentId.'/actions', $options));
+    }
+
+    public function getIncidentActionsByNumber(string $number, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/number/'.$number.'/actions', $options));
+    }
+
+    public function getIncidentAction(string $incidentId, string $actionId): object
+    {
+        return $this->get('api/incidents/id/'.$incidentId.'/actions/'.$actionId);
+    }
+
+    public function deleteIncidentAction(string $incidentId, string $actionId): array|object
+    {
+        return $this->delete('api/incidents/id/'.$incidentId.'/actions/'.$actionId);
+    }
+
+    // === Requests ===
+
+    public function getIncidentRequests(string $incidentId, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/id/'.$incidentId.'/requests', $options));
+    }
+
+    public function getIncidentRequestsByNumber(string $number, array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/number/'.$number.'/requests', $options));
+    }
+
+    public function getIncidentRequest(string $incidentId, string $requestId): object
+    {
+        return $this->get('api/incidents/id/'.$incidentId.'/requests/'.$requestId);
+    }
+
+    public function deleteIncidentRequest(string $incidentId, string $requestId): array|object
+    {
+        return $this->delete('api/incidents/id/'.$incidentId.'/requests/'.$requestId);
+    }
+
+    // === Time Spent ===
+
+    public function getTimeSpent(string $incidentId): Collection
+    {
+        return collect($this->get('api/incidents/id/'.$incidentId.'/timespent'));
+    }
+
+    public function getTimeSpentByNumber(string $number): Collection
+    {
+        return collect($this->get('api/incidents/number/'.$number.'/timespent'));
+    }
+
+    /**
+     * @param  array  $data  Keys: timeSpent (minutes int), notes, entryDate, operator{id}, operatorGroup{id}, reason{id}
+     */
+    public function registerTimeSpent(string $incidentId, array $data): object
+    {
+        return $this->post('api/incidents/id/'.$incidentId.'/timespent', $data);
+    }
+
+    /**
+     * @param  array  $data  Keys: timeSpent (minutes int), notes, entryDate, operator{id}, operatorGroup{id}, reason{id}
+     */
+    public function registerTimeSpentByNumber(string $number, array $data): object
+    {
+        return $this->post('api/incidents/number/'.$number.'/timespent', $data);
+    }
+
+    public function getTimeRegistrations(array $options = []): Collection
+    {
+        return collect($this->get('api/incidents/timeregistrations', $options));
+    }
+
+    public function getTimeRegistration(string $id): object
+    {
+        return $this->get('api/incidents/timeregistrations/'.$id);
+    }
+
+    // === Escalation / De-escalation ===
+
+    public function escalateIncident(string $incidentId, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/id/'.$incidentId.'/escalate', ['id' => $reasonId]);
+    }
+
+    public function escalateIncidentByNumber(string $number, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/number/'.$number.'/escalate', ['id' => $reasonId]);
+    }
+
+    public function deescalateIncident(string $incidentId, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/id/'.$incidentId.'/deescalate', ['id' => $reasonId]);
+    }
+
+    public function deescalateIncidentByNumber(string $number, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/number/'.$number.'/deescalate', ['id' => $reasonId]);
+    }
+
+    // === Archive / Unarchive ===
+
+    public function archiveIncident(string $incidentId, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/id/'.$incidentId.'/archive', ['id' => $reasonId]);
+    }
+
+    public function archiveIncidentByNumber(string $number, string $reasonId): array|object
+    {
+        return $this->put('api/incidents/number/'.$number.'/archive', ['id' => $reasonId]);
+    }
+
+    public function unarchiveIncident(string $incidentId): array|object
+    {
+        return $this->put('api/incidents/id/'.$incidentId.'/unarchive');
+    }
+
+    public function unarchiveIncidentByNumber(string $number): array|object
+    {
+        return $this->put('api/incidents/number/'.$number.'/unarchive');
+    }
+
+    // === Attachments ===
+
+    public function getIncidentAttachments(string $incidentId, array $options = []): Collection
+    {
+        return self::query()->get('api/incidents/id/'.$incidentId.'/attachments', $options)->throw()->collect();
+    }
+
+    public function getIncidentAttachmentsByNumber(string $number, array $options = []): Collection
+    {
+        return self::query()->get('api/incidents/number/'.$number.'/attachments', $options)->throw()->collect();
+    }
+
+    public function deleteIncidentAttachment(string $incidentId, string $attachmentId): array|object
+    {
+        return $this->delete('api/incidents/id/'.$incidentId.'/attachments/'.$attachmentId);
+    }
+}

--- a/src/Traits/IncidentLookups.php
+++ b/src/Traits/IncidentLookups.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait IncidentLookups
+{
+    public function getCallTypes(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_call_types', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/call_types')->throw()->collect());
+    }
+
+    public function getDurations(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_durations', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/durations')->throw()->collect());
+    }
+
+    public function getEntryTypes(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_entry_types', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/entry_types')->throw()->collect());
+    }
+
+    public function getImpacts(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_impacts', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/impacts')->throw()->collect());
+    }
+
+    public function getPriorities(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_priorities', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/priorities')->throw()->collect());
+    }
+
+    public function getUrgencies(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_urgencies', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/urgencies')->throw()->collect());
+    }
+
+    public function getClosureCodes(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_closure_codes', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/closure_codes')->throw()->collect());
+    }
+
+    public function getEscalationReasons(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_escalation_reasons', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/escalation-reasons')->throw()->collect());
+    }
+
+    public function getDeescalationReasons(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('incident_deescalation_reasons', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/deescalation-reasons')->throw()->collect());
+    }
+
+    public function getTimeSpentReasons(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('timespent_reasons', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/timespent-reasons')->throw()->collect());
+    }
+
+    /**
+     * @param  array  $options  Filters: incident, contract, person, service, branch, budgetHolder, department, etc.
+     */
+    public function getSlas(array $options = []): Collection
+    {
+        return self::query()->get('api/incidents/slas', $options)->throw()->collect();
+    }
+
+    public function getSlaServices(array $options = []): Collection
+    {
+        return self::query()->get('api/incidents/slas/services', $options)->throw()->collect();
+    }
+
+    public function getCategories(array $options = []): Collection
+    {
+        return self::query()->get('api/categories', $options)->throw()->collect();
+    }
+}

--- a/src/Traits/IncidentLookups.php
+++ b/src/Traits/IncidentLookups.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait IncidentLookups
 {

--- a/src/Traits/IncidentLookups.php
+++ b/src/Traits/IncidentLookups.php
@@ -14,70 +14,70 @@ trait IncidentLookups
     {
         $cacheKey = $this->setupCacheObject('incident_call_types', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/call_types')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/call_types')->throw()->collect());
     }
 
     public function getDurations(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_durations', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/durations')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/durations')->throw()->collect());
     }
 
     public function getEntryTypes(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_entry_types', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/entry_types')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/entry_types')->throw()->collect());
     }
 
     public function getImpacts(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_impacts', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/impacts')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/impacts')->throw()->collect());
     }
 
     public function getPriorities(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_priorities', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/priorities')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/priorities')->throw()->collect());
     }
 
     public function getUrgencies(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_urgencies', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/urgencies')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/urgencies')->throw()->collect());
     }
 
     public function getClosureCodes(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_closure_codes', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/closure_codes')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/closure_codes')->throw()->collect());
     }
 
     public function getEscalationReasons(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_escalation_reasons', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/escalation-reasons')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/escalation-reasons')->throw()->collect());
     }
 
     public function getDeescalationReasons(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('incident_deescalation_reasons', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/deescalation-reasons')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/incidents/deescalation-reasons')->throw()->collect());
     }
 
     public function getTimeSpentReasons(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('timespent_reasons', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/timespent-reasons')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/timespent-reasons')->throw()->collect());
     }
 
     /**

--- a/src/Traits/Incidents.php
+++ b/src/Traits/Incidents.php
@@ -47,7 +47,7 @@ trait Incidents
                     return $ticket;
                 });
             } catch (RequestException $exception) {
-                dd($exception->getMessage());
+                throw $exception;
             }
         });
     }

--- a/src/Traits/Incidents.php
+++ b/src/Traits/Incidents.php
@@ -8,9 +8,11 @@ use Carbon\Carbon;
 use FredBradley\EasyTime\EasySeconds;
 use FredBradley\TOPDesk\Exceptions\OperatorGroupNotFound;
 use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\Str;
 
 /**
@@ -54,7 +56,7 @@ trait Incidents
     /**
      * @param  array  $options  Keys: start, page_size, query (FIQL), fields, sort, etc.
      *
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException|ConnectionException
      */
     public function getListOfIncidents(array $options = []): array|object
     {
@@ -67,7 +69,7 @@ trait Incidents
      *                       priority{id}, impact{id}, urgency{id}, duration{id}, targetDate,
      *                       onHold, closed, closedDate, closureCode{id}, costs, etc.
      *
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function updateIncident(string $id, array $data): object
     {
@@ -75,7 +77,7 @@ trait Incidents
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function updateIncidentByNumber(string $number, array $data): object
     {
@@ -83,9 +85,9 @@ trait Incidents
     }
 
     /**
-     * @deprecated use getIncident() instead
+     * @throws RequestException|ConnectionException
      *
-     * @throws \Illuminate\Http\Client\RequestException
+     * @deprecated use getIncident() instead
      */
     public function getIncidentbyNumber(string $topdeskIncidentNumber): object
     {
@@ -95,7 +97,7 @@ trait Incidents
     /**
      * @param  string  $topdeskIncidentNumber  either the UNID or Ticket Number
      *
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException|ConnectionException
      */
     public function getIncident(string $topdeskIncidentNumber): object
     {
@@ -129,7 +131,7 @@ trait Incidents
     }
 
     /**
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function createIncident(array $options): object
     {
@@ -216,7 +218,7 @@ trait Incidents
     /**
      * @return \stdClass
      *
-     * @throws \Illuminate\Support\ItemNotFoundException
+     * @throws ItemNotFoundException
      */
     public function getProcessingStatus(string $name, bool $forgetCache = false): array
     {

--- a/src/Traits/Incidents.php
+++ b/src/Traits/Incidents.php
@@ -30,7 +30,7 @@ trait Incidents
             $processingStatus = 'Closed';
         }
 
-        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupId, $processingStatus, $processingStatusOperator) {
+        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupId, $processingStatus, $processingStatusOperator) {
             try {
                 $processingStatusId = $this->getProcessingStatusId($processingStatus);
                 $response = self::query()->get('api/incidents', [
@@ -142,7 +142,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('operator_'.$username, $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::months(1), function () use ($username) {
+        return self::cache()->remember($cacheKey, EasySeconds::months(1), function () use ($username) {
             $result = self::query()->get('api/operators', [
                 'page_size' => 1,
                 'query' => '(networkLoginName=='.$username.')',
@@ -170,7 +170,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('get_operator_group_name_'.$name, $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::months(1), function () use ($name) {
+        return self::cache()->remember($cacheKey, EasySeconds::months(1), function () use ($name) {
             $result = self::query()->get('api/operatorgroups/lookup', [
                 'name' => $name,
                 'archived' => false,
@@ -210,7 +210,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('getProcessingStatusId_'.$name, $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
             return $this->getProcessingStatus($name, $forgetCache)['id'];
         });
     }
@@ -224,7 +224,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('status_'.$name, $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
             $statuses = $this->getAllProcessingStatuses($forgetCache);
 
             return $statuses->where('name', $name)->first() ?? throw new \Exception('Status Not Found');
@@ -235,7 +235,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('statuses', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::days(30), function () {
+        return self::cache()->remember($cacheKey, EasySeconds::days(30), function () {
             return self::query()->get('api/incidents/statuses')->collect();
         });
     }

--- a/src/Traits/Incidents.php
+++ b/src/Traits/Incidents.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
 use Carbon\Carbon;
-use FredBradley\Cacher\Cacher;
-use FredBradley\Cacher\Exceptions\FrameworkNotDetected;
 use FredBradley\EasyTime\EasySeconds;
 use FredBradley\TOPDesk\Exceptions\OperatorGroupNotFound;
 use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 /**
@@ -17,9 +18,6 @@ use Illuminate\Support\Str;
  */
 trait Incidents
 {
-    /**
-     * @throws \FredBradley\Cacher\Exceptions\FrameworkNotDetected
-     */
     public function getOpenIncidentsByOperatorGroupId(string $operatorGroupId, string $processingStatus = 'Open', bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('open_incidents_'.$operatorGroupId.$processingStatus, $forgetCache);
@@ -30,7 +28,7 @@ trait Incidents
             $processingStatus = 'Closed';
         }
 
-        return Cacher::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupId, $processingStatus, $processingStatusOperator) {
+        return Cache::remember($cacheKey, EasySeconds::minutes(5), function () use ($operatorGroupId, $processingStatus, $processingStatusOperator) {
             try {
                 $processingStatusId = $this->getProcessingStatusId($processingStatus);
                 $response = self::query()->get('api/incidents', [
@@ -51,6 +49,37 @@ trait Incidents
                 dd($exception->getMessage());
             }
         });
+    }
+
+    /**
+     * @param  array  $options  Keys: start, page_size, query (FIQL), fields, sort, etc.
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function getListOfIncidents(array $options = []): array|object
+    {
+        return $this->get('api/incidents', array_merge(['start' => 0, 'page_size' => 100], $options));
+    }
+
+    /**
+     * @param  array  $data  Any incident fields: briefDescription, request, action, category{id},
+     *                       subcategory{id}, operator{id}, operatorGroup{id}, processingStatus{id},
+     *                       priority{id}, impact{id}, urgency{id}, duration{id}, targetDate,
+     *                       onHold, closed, closedDate, closureCode{id}, costs, etc.
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function updateIncident(string $id, array $data): object
+    {
+        return $this->patch('api/incidents/id/'.$id, $data);
+    }
+
+    /**
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function updateIncidentByNumber(string $number, array $data): object
+    {
+        return $this->patch('api/incidents/number/'.$number, $data);
     }
 
     /**
@@ -107,11 +136,11 @@ trait Incidents
         return $this->post('api/incidents', $options);
     }
 
-    public function getOperatorByUsername(string $username, $forgetCache = false): Collection|\stdClass
+    public function getOperatorByUsername(string $username, bool $forgetCache = false): Collection|\stdClass
     {
         $cacheKey = $this->setupCacheObject('operator_'.$username, $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::months(1), function () use ($username) {
+        return Cache::remember($cacheKey, EasySeconds::months(1), function () use ($username) {
             $result = self::query()->get('api/operators', [
                 'page_size' => 1,
                 'query' => '(networkLoginName=='.$username.')',
@@ -139,7 +168,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('get_operator_group_name_'.$name, $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::months(1), function () use ($name) {
+        return Cache::remember($cacheKey, EasySeconds::months(1), function () use ($name) {
             $result = self::query()->get('api/operatorgroups/lookup', [
                 'name' => $name,
                 'archived' => false,
@@ -179,7 +208,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('getProcessingStatusId_'.$name, $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
             return $this->getProcessingStatus($name, $forgetCache)['id'];
         });
     }
@@ -193,7 +222,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('status_'.$name, $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), function () use ($name, $forgetCache) {
             $statuses = $this->getAllProcessingStatuses($forgetCache);
 
             return $statuses->where('name', $name)->first() ?? throw new \Exception('Status Not Found');
@@ -204,7 +233,7 @@ trait Incidents
     {
         $cacheKey = $this->setupCacheObject('statuses', $forgetCache);
 
-        return Cacher::remember($cacheKey, EasySeconds::days(30), function () {
+        return Cache::remember($cacheKey, EasySeconds::days(30), function () {
             return self::query()->get('api/incidents/statuses')->collect();
         });
     }

--- a/src/Traits/Incidents.php
+++ b/src/Traits/Incidents.php
@@ -11,7 +11,6 @@ use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\Str;
 

--- a/src/Traits/Locations.php
+++ b/src/Traits/Locations.php
@@ -60,20 +60,20 @@ trait Locations
     {
         $cacheKey = $this->setupCacheObject('location_types', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/types')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/types')->throw()->collect());
     }
 
     public function getLocationStatuses(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('location_statuses', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/statuses')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/statuses')->throw()->collect());
     }
 
     public function getBuildingZones(bool $forgetCache = false): Collection
     {
         $cacheKey = $this->setupCacheObject('building_zones', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/building_zones')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/building_zones')->throw()->collect());
     }
 }

--- a/src/Traits/Locations.php
+++ b/src/Traits/Locations.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait Locations
 {

--- a/src/Traits/Locations.php
+++ b/src/Traits/Locations.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait Locations
+{
+    /**
+     * @param  array  $query  Supports FIQL via 'query' key and field selection via '$fields'
+     */
+    public function getLocations(array $query = []): Collection
+    {
+        return self::query()->get('api/locations', $query)->throw()->collect();
+    }
+
+    public function getLocation(string $id): object
+    {
+        return $this->get('api/locations/id/'.$id);
+    }
+
+    /**
+     * @param  array  $data  Keys: name, roomNumber, branch{id}, functionalUse{id}, type{id},
+     *                       capacity, specification, budgetHolder{id}, buildingZone{id},
+     *                       roomStatus{id}, roomSetup, majorLocation{id}, area, notes, etc.
+     */
+    public function createLocation(array $data): object
+    {
+        return $this->post('api/locations', $data);
+    }
+
+    public function updateLocation(string $id, array $data): object
+    {
+        return $this->patch('api/locations/id/'.$id, $data);
+    }
+
+    public function archiveLocation(string $id): array|object
+    {
+        return $this->patch('api/locations/id/'.$id.'/archive');
+    }
+
+    public function unarchiveLocation(string $id): array|object
+    {
+        return $this->patch('api/locations/id/'.$id.'/unarchive');
+    }
+
+    /**
+     * @param  array  $options  Keys: $top (max 10000), name (prefix filter), archived
+     */
+    public function getLocationLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/locations/lookup', $options)->throw()->collect();
+    }
+
+    public function getLocationTypes(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('location_types', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/types')->throw()->collect());
+    }
+
+    public function getLocationStatuses(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('location_statuses', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/statuses')->throw()->collect());
+    }
+
+    public function getBuildingZones(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('building_zones', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/locations/building_zones')->throw()->collect());
+    }
+}

--- a/src/Traits/OperatorManagement.php
+++ b/src/Traits/OperatorManagement.php
@@ -119,6 +119,6 @@ trait OperatorManagement
     {
         $cacheKey = $this->setupCacheObject('permission_groups', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/permissiongroups')->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/permissiongroups')->throw()->collect());
     }
 }

--- a/src/Traits/OperatorManagement.php
+++ b/src/Traits/OperatorManagement.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait OperatorManagement
 {

--- a/src/Traits/OperatorManagement.php
+++ b/src/Traits/OperatorManagement.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait OperatorManagement
+{
+    // === Operators ===
+
+    public function getOperatorById(string $id, array $fields = []): object
+    {
+        $query = empty($fields) ? [] : ['fields' => implode(',', $fields)];
+
+        return $this->get('api/operators/id/'.$id, $query);
+    }
+
+    /**
+     * @param  array  $data  Keys: surName, firstName, firstInitials, loginName, loginPermission, password,
+     *                       email, telephone, mobileNumber, networkLoginName, branch{id}, location{id},
+     *                       department{id}, budgetHolder{id}, language{id}, jobTitle, linkedPerson{id},
+     *                       firstLineCallOperator, secondLineCallOperator, changeCoordinator, etc.
+     */
+    public function createOperator(array $data): object
+    {
+        return $this->post('api/operators', $data);
+    }
+
+    public function updateOperator(string $id, array $data): object
+    {
+        return $this->patch('api/operators/id/'.$id, $data);
+    }
+
+    public function archiveOperator(string $id): array|object
+    {
+        return $this->patch('api/operators/id/'.$id.'/archive');
+    }
+
+    public function unarchiveOperator(string $id): array|object
+    {
+        return $this->patch('api/operators/id/'.$id.'/unarchive');
+    }
+
+    public function getCurrentOperator(array $fields = []): object
+    {
+        $query = empty($fields) ? [] : ['fields' => implode(',', $fields)];
+
+        return $this->get('api/operators/current', $query);
+    }
+
+    public function getCurrentOperatorId(): string
+    {
+        return $this->get('api/operators/current/id');
+    }
+
+    /**
+     * @param  array  $options  Keys: $top, name (prefix filter)
+     */
+    public function getOperatorLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/operators/lookup', $options)->throw()->collect();
+    }
+
+    // === Operator Groups ===
+
+    /**
+     * @param  array  $query  Keys: start, page_size, query (FIQL), fields
+     */
+    public function getOperatorGroups(array $query = []): Collection
+    {
+        return self::query()->get('api/operatorgroups', $query)->throw()->collect();
+    }
+
+    public function getOperatorGroupById(string $id): object
+    {
+        return $this->get('api/operatorgroups/id/'.$id);
+    }
+
+    /**
+     * @param  array  $data  Keys: groupName, branch{id}, contact{id}, accessRoles
+     */
+    public function createOperatorGroup(array $data): object
+    {
+        return $this->post('api/operatorgroups', $data);
+    }
+
+    public function updateOperatorGroup(string $id, array $data): object
+    {
+        return $this->patch('api/operatorgroups/id/'.$id, $data);
+    }
+
+    public function archiveOperatorGroup(string $id): array|object
+    {
+        return $this->patch('api/operatorgroups/id/'.$id.'/archive');
+    }
+
+    public function unarchiveOperatorGroup(string $id): array|object
+    {
+        return $this->patch('api/operatorgroups/id/'.$id.'/unarchive');
+    }
+
+    public function getOperatorGroupLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/operatorgroups/lookup', $options)->throw()->collect();
+    }
+
+    public function getOperatorGroupOperators(string $id): Collection
+    {
+        return self::query()->get('api/operatorgroups/id/'.$id.'/operators')->throw()->collect();
+    }
+
+    // === Permission Groups ===
+
+    public function getPermissionGroups(bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('permission_groups', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::weeks(1), fn () => self::query()->get('api/permissiongroups')->throw()->collect());
+    }
+}

--- a/src/Traits/OperatorStats.php
+++ b/src/Traits/OperatorStats.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait OperatorStats
 {
@@ -28,6 +27,7 @@ trait OperatorStats
                 'query' => '(operatorGroup.id=='.$operatorGroupId.')',
             ]))->toArray()
         );
+
         return collect($data);
     }
 

--- a/src/Traits/OperatorStats.php
+++ b/src/Traits/OperatorStats.php
@@ -20,7 +20,7 @@ trait OperatorStats
     {
         $operatorGroupId = $this->getOperatorGroupId($name);
 
-        $data = Cache::remember(
+        $data = self::cache()->remember(
             'get_operators_'.$operatorGroupId,
             EasySeconds::weeks(1),
             fn () => collect($this->get('api/operators', [
@@ -81,7 +81,7 @@ trait OperatorStats
 
     public function getClosedIncidentsForOperator(string $operatorId): array
     {
-        return Cache::remember(
+        return self::cache()->remember(
             'resolvedIncidentsByOperator_'.$operatorId,
             EasySeconds::minutes(5),
             function () use ($operatorId) {

--- a/src/Traits/OperatorStats.php
+++ b/src/Traits/OperatorStats.php
@@ -1,81 +1,73 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
-use FredBradley\Cacher\Cacher;
 use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 
-/**
- * Trait OperatorStats.
- */
 trait OperatorStats
 {
-    public function getOperatorsByOperatorGroup(string $name): array
+    /*
+     * Pattern: return Collection instead of a plain array from API calls.
+     * Collection gives callers chainable higher-order operations (filter, map,
+     * pluck, etc.) without forcing them to write their own foreach loops.
+     */
+
+    public function getOperatorsByOperatorGroup(string $name): Collection
     {
         $operatorGroupId = $this->getOperatorGroupId($name);
 
-        return Cacher::remember(
+        return Cache::remember(
             'get_operators_'.$operatorGroupId,
             EasySeconds::weeks(1),
-            function () use ($operatorGroupId) {
-                return $this->get(
-                    'api/operators',
-                    [
-                        'page_size' => 100,
-                        'query' => '(operatorGroup.id=='.$operatorGroupId.')',
-                    ]
-                );
-            }
+            fn () => collect($this->get('api/operators', [
+                'page_size' => 100,
+                'query' => '(operatorGroup.id=='.$operatorGroupId.')',
+            ]))
         );
     }
 
     public function openCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsernames = []): array
     {
-        $operators = $this->getOperatorsByOperatorGroup($name);
-
-        $results = [];
-        foreach ($operators as $operator) {
-            if (! in_array($operator->networkLoginName, $ignoreUsernames)) {
-                $results[$operator->networkLoginName] = $this->countOpenTicketsByOperator($operator->id);
-            }
-        }
-
-        return $results;
+        return $this->getOperatorsByOperatorGroup($name)
+            ->reject(fn ($operator) => in_array($operator->networkLoginName, $ignoreUsernames))
+            ->mapWithKeys(fn ($operator) => [$operator->networkLoginName => $this->countOpenTicketsByOperator($operator->id)])
+            ->all();
     }
 
     public function activeCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsernames = []): array
     {
-        $operators = $this->getOperatorsByOperatorGroup($name);
-        $results = [];
-        foreach ($operators as $operator) {
-            if (! in_array($operator['networkLoginName'], $ignoreUsernames)) {
-                $results[$operator['networkLoginName']] = $this->countActiveTicketsByOperator($operator['id']);
-            }
-        }
-
-        return $results;
+        /*
+         * Pattern: consistent property access on stdClass objects returned by
+         * the HTTP layer. Previously this method used array access ($operator['id'])
+         * while the surrounding methods used property access ($operator->id) on the
+         * same objects — now unified to property access throughout.
+         */
+        return $this->getOperatorsByOperatorGroup($name)
+            ->reject(fn ($operator) => in_array($operator->networkLoginName, $ignoreUsernames))
+            ->mapWithKeys(fn ($operator) => [$operator->networkLoginName => $this->countActiveTicketsByOperator($operator->id)])
+            ->all();
     }
 
     /**
      * @deprecated Use closedTicketCountsForOperatorGroup
      */
-    public function resolveCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsername = []): array
+    public function resolveCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsernames = []): array
     {
-        return $this->closedTicketCountsForOperatorGroup($name, $ignoreUsername);
+        return $this->closedTicketCountsForOperatorGroup($name, $ignoreUsernames);
     }
 
     public function closedTicketCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsernames = []): array
     {
-        $operators = $this->getOperatorsByOperatorGroup($name);
-        $results = [];
+        $lowerIgnore = array_map('strtolower', $ignoreUsernames);
 
-        foreach ($operators as $operator) {
-            if (! in_array(strtolower($operator->networkLoginName), array_map('strtolower', $ignoreUsernames))) {
-                $results[$operator->networkLoginName] = $this->getClosedIncidentsForOperator($operator->id); // changed method to getResolvedIncidentsForOperator to as not to include change requests, which we know longer have access to
-            }
-        }
-
-        return $results;
+        return $this->getOperatorsByOperatorGroup($name)
+            ->reject(fn ($operator) => in_array(strtolower($operator->networkLoginName), $lowerIgnore))
+            ->mapWithKeys(fn ($operator) => [$operator->networkLoginName => $this->getClosedIncidentsForOperator($operator->id)])
+            ->all();
     }
 
     /**
@@ -88,7 +80,7 @@ trait OperatorStats
 
     public function getClosedIncidentsForOperator(string $operatorId): array
     {
-        return Cacher::remember(
+        return Cache::remember(
             'resolvedIncidentsByOperator_'.$operatorId,
             EasySeconds::minutes(5),
             function () use ($operatorId) {
@@ -109,24 +101,10 @@ trait OperatorStats
     }
 
     /**
-     * Is the sum of Incidents and Change Activities...
-     *
-     *
-     * @deprecated
+     * @deprecated Use getClosedIncidentsForOperator
      */
     public function getResolvedTicketsForOperator(string $operatorId): array
     {
         return $this->getClosedIncidentsForOperator($operatorId);
-    }
-
-    private function sumTwoArrays(array $arrayOne, array $arrayTwo): array
-    {
-        $sums = [];
-
-        foreach (array_keys($arrayOne + $arrayTwo) as $total) {
-            $sums[$total] = (isset($arrayOne[$total]) ? $arrayOne[$total] : 0) + (isset($arrayTwo) ? $arrayTwo[$total] : 0);
-        }
-
-        return $sums;
     }
 }

--- a/src/Traits/OperatorStats.php
+++ b/src/Traits/OperatorStats.php
@@ -20,14 +20,15 @@ trait OperatorStats
     {
         $operatorGroupId = $this->getOperatorGroupId($name);
 
-        return Cache::remember(
+        $data = Cache::remember(
             'get_operators_'.$operatorGroupId,
             EasySeconds::weeks(1),
             fn () => collect($this->get('api/operators', [
                 'page_size' => 100,
                 'query' => '(operatorGroup.id=='.$operatorGroupId.')',
-            ]))
+            ]))->toArray()
         );
+        return collect($data);
     }
 
     public function openCountsForOperatorGroup(string $name = 'I.T. Services', array $ignoreUsernames = []): array

--- a/src/Traits/PersonManagement.php
+++ b/src/Traits/PersonManagement.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use Illuminate\Support\Collection;
+
+trait PersonManagement
+{
+    /**
+     * @param  array  $data  All person fields; at minimum surName is required.
+     *                       Keys: surName, firstName, firstInitials, prefixes, networkLoginName,
+     *                       tasLoginName, hasSspAccess, branch{id}, location{id}, department{id},
+     *                       budgetHolder{id}, language{id}, phoneNumber, mobileNumber, email,
+     *                       jobTitle, isManager, manager{id}, isCaller, etc.
+     */
+    public function createPerson(array $data): object
+    {
+        return $this->post('api/persons', $data);
+    }
+
+    public function updatePerson(string $id, array $data): object
+    {
+        return $this->patch('api/persons/'.$id, $data);
+    }
+
+    public function archivePerson(string $id): array|object
+    {
+        return $this->patch('api/persons/id/'.$id.'/archive');
+    }
+
+    public function unarchivePerson(string $id): array|object
+    {
+        return $this->patch('api/persons/id/'.$id.'/unarchive');
+    }
+
+    public function getCurrentPerson(): object
+    {
+        return $this->get('api/persons/current');
+    }
+
+    public function getPersonCount(): int
+    {
+        return (int) $this->get('api/persons/count');
+    }
+
+    /**
+     * @param  array  $options  Keys: $top, name (prefix filter)
+     */
+    public function getPersonLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/persons/lookup', $options)->throw()->collect();
+    }
+
+    public function getPersonGroupsForPerson(string $personId): Collection
+    {
+        return self::query()->get('api/persons/'.$personId.'/persongroups')->throw()->collect();
+    }
+
+    // === Person Groups ===
+
+    /**
+     * @param  array  $query  Keys: pageStart, pageSize, fields, sort, query (FIQL)
+     */
+    public function getPersonGroups(array $query = []): Collection
+    {
+        return self::query()->get('api/persongroups', $query)->throw()->collect();
+    }
+
+    public function getPersonGroup(string $id): object
+    {
+        return $this->get('api/persongroups/'.$id);
+    }
+
+    /**
+     * @param  array  $options  Keys: pageStart, pageSize, fields, sort, query
+     */
+    public function getPersonGroupPersons(string $id, array $options = []): Collection
+    {
+        return self::query()->get('api/persongroups/'.$id.'/persons', $options)->throw()->collect();
+    }
+
+    /**
+     * @param  array  $data  Keys: name, phoneNumber, fax, email, branch{id}, location{id},
+     *                       department{id}, budgetHolder{id}, contactPerson{id}, optionalFields1, optionalFields2
+     */
+    public function createPersonGroup(array $data): object
+    {
+        return $this->post('api/persongroups', $data);
+    }
+
+    public function updatePersonGroup(string $id, array $data): object
+    {
+        return $this->patch('api/persongroups/'.$id, $data);
+    }
+
+    public function archivePersonGroup(string $id): array|object
+    {
+        return $this->post('api/persongroups/'.$id.'/archive', []);
+    }
+
+    public function unarchivePersonGroup(string $id): array|object
+    {
+        return $this->post('api/persongroups/id/'.$id.'/unarchive', []);
+    }
+
+    /**
+     * @param  array  $options  Keys: $top, name (prefix filter)
+     */
+    public function getPersonGroupLookup(array $options = []): Collection
+    {
+        return self::query()->get('api/persongroups/lookup', $options)->throw()->collect();
+    }
+}

--- a/src/Traits/Persons.php
+++ b/src/Traits/Persons.php
@@ -12,7 +12,7 @@ trait Persons
 {
     /**
      * @throws PersonNotFound
-     * @throws RequestException
+     * @throws RequestException|ConnectionException
      */
     public function getPersonByUsername(string $username): object
     {

--- a/src/Traits/Persons.php
+++ b/src/Traits/Persons.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FredBradley\TOPDesk\Traits;
 
-use Illuminate\Http\Client\RequestException;
+use FredBradley\TOPDesk\Exceptions\PersonNotFound;
 
 trait Persons
 {
     /**
-     * @param  string  $username
-     * @return object
-     *
-     * @throws RequestException
+     * @throws PersonNotFound
+     * @throws \Illuminate\Http\Client\RequestException
      */
     public function getPersonByUsername(string $username): object
     {
@@ -19,17 +19,23 @@ trait Persons
         ])->throw()->collect();
 
         if ($result->isEmpty()) {
-            throw new \Exception('Person Not Found', 404);
+            // Pattern: named domain exception instead of the base \Exception class.
+            // Callers can catch PersonNotFound specifically, and the 404 code means
+            // HTTP layers (e.g. Handler::render) can map it to a response automatically.
+            throw new PersonNotFound($username);
         }
 
         return (object) $result->first();
     }
 
     /**
-     * @throws RequestException
+     * Uses the v2 persons endpoint (/persons/{id}) which does not require the
+     * intermediate /id/ segment present in older API versions.
+     *
+     * @throws \Illuminate\Http\Client\RequestException
      */
     public function getPersonById(string $id): object
     {
-        return $this->get('api/persons/id/'.$id);
+        return $this->get('api/persons/'.$id);
     }
 }

--- a/src/Traits/Persons.php
+++ b/src/Traits/Persons.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\TOPDesk\Exceptions\PersonNotFound;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 
 trait Persons
 {
     /**
      * @throws PersonNotFound
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException
      */
     public function getPersonByUsername(string $username): object
     {
@@ -32,10 +34,14 @@ trait Persons
      * Uses the v2 persons endpoint (/persons/{id}) which does not require the
      * intermediate /id/ segment present in older API versions.
      *
-     * @throws \Illuminate\Http\Client\RequestException
+     * @throws RequestException|ConnectionException
      */
     public function getPersonById(string $id): object
     {
-        return $this->get('api/persons/'.$id);
+        return $this->process(
+            self::query()
+                ->accept('application/x-topdesk-v2+json')
+                ->get('api/persons/'.$id)
+        );
     }
 }

--- a/src/Traits/Persons.php
+++ b/src/Traits/Persons.php
@@ -40,7 +40,7 @@ trait Persons
     {
         return $this->process(
             self::query()
-                ->accept('application/x-topdesk-v2+json')
+                ->accept('application/x.topdesk-person-v2+json')
                 ->get('api/persons/'.$id)
         );
     }

--- a/src/Traits/Suppliers.php
+++ b/src/Traits/Suppliers.php
@@ -6,7 +6,6 @@ namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 
 trait Suppliers
 {

--- a/src/Traits/Suppliers.php
+++ b/src/Traits/Suppliers.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace FredBradley\TOPDesk\Traits;
 
 use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
 
 trait Suppliers
 {
     /**
      * @param  array  $query  Keys: start, page_size, query (FIQL)
+     *
+     * @throws ConnectionException|RequestException
      */
     public function getSuppliers(array $query = []): Collection
     {

--- a/src/Traits/Suppliers.php
+++ b/src/Traits/Suppliers.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Traits;
+
+use FredBradley\EasyTime\EasySeconds;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+trait Suppliers
+{
+    /**
+     * @param  array  $query  Keys: start, page_size, query (FIQL)
+     */
+    public function getSuppliers(array $query = []): Collection
+    {
+        return self::query()->get('api/suppliers', $query)->throw()->collect();
+    }
+
+    public function getSupplier(string $id): object
+    {
+        return $this->get('api/suppliers/'.$id);
+    }
+
+    /**
+     * @param  array  $options  Keys: $top, name (prefix filter), archived
+     */
+    public function getSupplierLookup(array $options = [], bool $forgetCache = false): Collection
+    {
+        $cacheKey = $this->setupCacheObject('supplier_lookup', $forgetCache);
+
+        return Cache::remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/suppliers/lookup', $options)->throw()->collect());
+    }
+
+    /**
+     * @param  array  $query  Keys: start, page_size
+     */
+    public function getSupplierContacts(array $query = []): Collection
+    {
+        return self::query()->get('api/supplierContacts', $query)->throw()->collect();
+    }
+
+    public function getSupplierContact(string $id): object
+    {
+        return $this->get('api/supplierContacts/'.$id);
+    }
+}

--- a/src/Traits/Suppliers.php
+++ b/src/Traits/Suppliers.php
@@ -30,7 +30,7 @@ trait Suppliers
     {
         $cacheKey = $this->setupCacheObject('supplier_lookup', $forgetCache);
 
-        return Cache::remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/suppliers/lookup', $options)->throw()->collect());
+        return self::cache()->remember($cacheKey, EasySeconds::hours(1), fn () => self::query()->get('api/suppliers/lookup', $options)->throw()->collect());
     }
 
     /**

--- a/tests/Feature/AssetsTest.php
+++ b/tests/Feature/AssetsTest.php
@@ -20,8 +20,7 @@ it('lists assets via GET api/assetmgmt/assets', function () {
 
     TOPDesk::getListOfAssets();
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'GET' &&
+    Http::assertSent(fn ($r) => $r->method() === 'GET' &&
         str_contains($r->url(), 'api/assetmgmt/assets')
     );
 });
@@ -45,8 +44,7 @@ it('creates an asset by template id via POST', function () {
     $result = TOPDesk::createAssetByTemplateId('tmpl-uuid', ['name' => 'LAPTOP-002']);
 
     expect($result)->toBeObject()->and($result->id)->toBe('new-asset');
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'POST' &&
+    Http::assertSent(fn ($r) => $r->method() === 'POST' &&
         str_contains($r->url(), 'assetmgmt/assets/templateId/tmpl-uuid')
     );
 });
@@ -56,8 +54,7 @@ it('updates an asset by template id via PATCH', function () {
 
     TOPDesk::updateAssetByTemplateId('tmpl-uuid', 'asset-uuid', ['serialNumber' => 'SN999']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'assetmgmt/assets/templateId/tmpl-uuid/asset-uuid')
     );
 });
@@ -67,8 +64,7 @@ it('archives an asset via POST to api/assetmgmt/assets/{id}/archive', function (
 
     TOPDesk::archiveAsset('asset-uuid');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'POST' &&
+    Http::assertSent(fn ($r) => $r->method() === 'POST' &&
         str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/archive')
     );
 });
@@ -86,8 +82,7 @@ it('deletes assets via POST to api/assetmgmt/assets/delete with an assetIds arra
 
     TOPDesk::deleteAssets(['asset-1', 'asset-2']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'POST' &&
+    Http::assertSent(fn ($r) => $r->method() === 'POST' &&
         str_contains($r->url(), 'assetmgmt/assets/delete')
     );
 });
@@ -105,8 +100,7 @@ it('adds an asset assignment via PUT', function () {
 
     TOPDesk::addAssetAssignment('asset-uuid', ['person' => ['id' => 'person-uuid']]);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PUT' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' &&
         str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments')
     );
 });
@@ -116,8 +110,7 @@ it('removes an asset assignment via DELETE', function () {
 
     TOPDesk::removeAssetAssignment('asset-uuid', 'link-1');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'DELETE' &&
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE' &&
         str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments/link-1')
     );
 });
@@ -128,7 +121,7 @@ it('returns asset statuses as a cached Collection', function () {
         ['id' => 's-2', 'name' => 'In stock'],
     ])]);
 
-    $first  = TOPDesk::getAssetStatuses();
+    $first = TOPDesk::getAssetStatuses();
     $second = TOPDesk::getAssetStatuses();
 
     expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(2);

--- a/tests/Feature/AssetsTest.php
+++ b/tests/Feature/AssetsTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('fetches an asset by id via GET api/assetmgmt/assets/{id}', function () {
+    Http::fake(['*api/assetmgmt/assets/*' => Http::response(['id' => 'asset-uuid', 'name' => 'LAPTOP-001'])]);
+
+    $result = TOPDesk::getAsset('asset-uuid');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('asset-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid'));
+});
+
+it('lists assets via GET api/assetmgmt/assets', function () {
+    Http::fake(['*api/assetmgmt/assets*' => Http::response(['dataSet' => [['id' => 'a-1']]])]);
+
+    TOPDesk::getListOfAssets();
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'GET' &&
+        str_contains($r->url(), 'api/assetmgmt/assets')
+    );
+});
+
+it('updates an asset via POST (not PATCH) to api/assetmgmt/assets/{id}', function () {
+    Http::fake(['*api/assetmgmt/assets/asset-uuid*' => Http::response(['id' => 'asset-uuid'])]);
+
+    TOPDesk::updateAsset('asset-uuid', ['name' => 'Updated Name']);
+
+    Http::assertSent(function ($r) {
+        $path = parse_url($r->url(), PHP_URL_PATH);
+
+        return $r->method() === 'POST'
+            && str_ends_with($path, '/api/assetmgmt/assets/asset-uuid');
+    });
+});
+
+it('creates an asset by template id via POST', function () {
+    Http::fake(['*assetmgmt/assets/templateId/*' => Http::response(['id' => 'new-asset'])]);
+
+    $result = TOPDesk::createAssetByTemplateId('tmpl-uuid', ['name' => 'LAPTOP-002']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-asset');
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'POST' &&
+        str_contains($r->url(), 'assetmgmt/assets/templateId/tmpl-uuid')
+    );
+});
+
+it('updates an asset by template id via PATCH', function () {
+    Http::fake(['*assetmgmt/assets/templateId/*' => Http::response(['id' => 'asset-uuid'])]);
+
+    TOPDesk::updateAssetByTemplateId('tmpl-uuid', 'asset-uuid', ['serialNumber' => 'SN999']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'assetmgmt/assets/templateId/tmpl-uuid/asset-uuid')
+    );
+});
+
+it('archives an asset via POST to api/assetmgmt/assets/{id}/archive', function () {
+    Http::fake(['*archive*' => Http::response('', 204)]);
+
+    TOPDesk::archiveAsset('asset-uuid');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'POST' &&
+        str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/archive')
+    );
+});
+
+it('unarchives an asset via POST to api/assetmgmt/assets/{id}/unarchive', function () {
+    Http::fake(['*unarchive*' => Http::response('', 204)]);
+
+    TOPDesk::unarchiveAsset('asset-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/unarchive'));
+});
+
+it('deletes assets via POST to api/assetmgmt/assets/delete with an assetIds array', function () {
+    Http::fake(['*assetmgmt/assets/delete*' => Http::response('', 204)]);
+
+    TOPDesk::deleteAssets(['asset-1', 'asset-2']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'POST' &&
+        str_contains($r->url(), 'assetmgmt/assets/delete')
+    );
+});
+
+it('fetches asset assignments via GET', function () {
+    Http::fake(['*assignments*' => Http::response([['id' => 'link-1']])]);
+
+    TOPDesk::getAssetAssignments('asset-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments'));
+});
+
+it('adds an asset assignment via PUT', function () {
+    Http::fake(['*assignments*' => Http::response(['id' => 'link-new'])]);
+
+    TOPDesk::addAssetAssignment('asset-uuid', ['person' => ['id' => 'person-uuid']]);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PUT' &&
+        str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments')
+    );
+});
+
+it('removes an asset assignment via DELETE', function () {
+    Http::fake(['*assignments/link-1*' => Http::response('', 204)]);
+
+    TOPDesk::removeAssetAssignment('asset-uuid', 'link-1');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'DELETE' &&
+        str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments/link-1')
+    );
+});
+
+it('returns asset statuses as a cached Collection', function () {
+    Http::fake(['*assetmgmt/assetStatuses*' => Http::response([
+        ['id' => 's-1', 'name' => 'In use'],
+        ['id' => 's-2', 'name' => 'In stock'],
+    ])]);
+
+    $first  = TOPDesk::getAssetStatuses();
+    $second = TOPDesk::getAssetStatuses();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSentCount(1); // second call served from cache
+});
+
+it('returns card types as a cached Collection', function () {
+    Http::fake(['*assetmgmt/cardTypes*' => Http::response([['id' => 'ct-1', 'name' => 'Hardware']])]);
+
+    $result = TOPDesk::getCardTypes();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('resolves an asset template id by display name', function () {
+    Http::fake(['*assetmgmt/templates*' => Http::response([
+        'dataSet' => [
+            ['id' => 'tmpl-1', 'text' => 'Laptop'],
+            ['id' => 'tmpl-2', 'text' => 'Monitor'],
+        ],
+    ])]);
+
+    $id = TOPDesk::getAssetTemplateId('Laptop');
+
+    expect($id)->toBe('tmpl-1');
+});
+
+it('returns asset history via GET', function () {
+    Http::fake(['*history/pastItems*' => Http::response([['id' => 'hist-1']])]);
+
+    TOPDesk::getAssetHistory('asset-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/history/pastItems'));
+});

--- a/tests/Feature/AssetsTest.php
+++ b/tests/Feature/AssetsTest.php
@@ -156,3 +156,89 @@ it('returns asset history via GET', function () {
 
     Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/history/pastItems'));
 });
+
+it('returns asset current items via GET to history/currentItems', function () {
+    Http::fake(['*history/currentItems*' => Http::response([['id' => 'item-1', 'name' => 'LAPTOP-001']])]);
+
+    TOPDesk::getAssetCurrentItems('asset-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/history/currentItems'));
+});
+
+it('assigns an incident to an asset via PUT to api/assetmgmt/assets/{id}/assignments', function () {
+    Http::fake(['*assignments*' => Http::response(['id' => 'link-new'])]);
+
+    $result = TOPDesk::assignIncidentToAsset('asset-uuid', 'inc-uuid');
+
+    expect($result)->toBeObject();
+    Http::assertSent(fn ($r) => $r->method() === 'PUT'
+        && str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/assignments')
+    );
+});
+
+it('links an incident to an asset via POST to api/assetmgmt/assets/linkedTask', function () {
+    Http::fake(['*assetmgmt/assets/linkedTask*' => Http::response(['status' => 'ok'])]);
+
+    $result = TOPDesk::linkIncidentToAsset('asset-uuid', 'inc-uuid');
+
+    expect($result)->toBeObject();
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), 'api/assetmgmt/assets/linkedTask')
+    );
+});
+
+it('copies an asset via POST to api/assetmgmt/assets/{id}/copy', function () {
+    Http::fake(['*assetmgmt/assets/asset-uuid/copy*' => Http::response(['id' => 'asset-copy'])]);
+
+    $result = TOPDesk::copyAsset('asset-uuid');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('asset-copy');
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid/copy')
+    );
+});
+
+it('returns asset links via GET to api/assetmgmt/assetLinks', function () {
+    Http::fake(['*assetmgmt/assetLinks*' => Http::response([['id' => 'link-1', 'sourceId' => 'asset-a']])]);
+
+    $result = TOPDesk::getAssetLinks(['sourceId' => 'asset-a']);
+
+    Http::assertSent(fn ($r) => $r->method() === 'GET'
+        && str_contains($r->url(), 'api/assetmgmt/assetLinks')
+    );
+});
+
+it('creates an asset link via POST to api/assetmgmt/assetLinks', function () {
+    Http::fake(['*assetmgmt/assetLinks*' => Http::response(['id' => 'new-link'])]);
+
+    $result = TOPDesk::createAssetLink(['sourceId' => 'asset-a', 'targetId' => 'asset-b', 'capabilityId' => 'cap-1']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-link');
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), 'api/assetmgmt/assetLinks')
+    );
+});
+
+it('deletes an asset link via DELETE', function () {
+    Http::fake(['*assetmgmt/assetLinks/link-1*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteAssetLink('link-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'api/assetmgmt/assetLinks/link-1')
+    );
+});
+
+it('returns asset templates as a cached Collection', function () {
+    Http::fake(['*assetmgmt/templates*' => Http::response([
+        'dataSet' => [
+            ['id' => 'tmpl-1', 'text' => 'Laptop'],
+            ['id' => 'tmpl-2', 'text' => 'Monitor'],
+        ],
+    ])]);
+
+    $result = TOPDesk::getAssetTemplates();
+
+    expect($result)->toBeInstanceOf(Collection::class);
+});

--- a/tests/Feature/BranchesTest.php
+++ b/tests/Feature/BranchesTest.php
@@ -41,8 +41,7 @@ it('updates a branch via PATCH to api/branches/id/{id}', function () {
 
     TOPDesk::updateBranch('br-1', ['phone' => '+44 20 0000 0000']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/branches/id/br-1')
     );
 });
@@ -52,8 +51,7 @@ it('archives a branch via PATCH to api/branches/id/{id}/archive', function () {
 
     TOPDesk::archiveBranch('br-1');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/branches/id/br-1/archive')
     );
 });
@@ -61,7 +59,7 @@ it('archives a branch via PATCH to api/branches/id/{id}/archive', function () {
 it('resolves a branch id by name from the lookup endpoint (cached)', function () {
     Http::fake(['*api/branches/lookup*' => Http::response([['id' => 'br-1', 'name' => 'London HQ']])]);
 
-    $first  = TOPDesk::getBranchId('London HQ');
+    $first = TOPDesk::getBranchId('London HQ');
     $second = TOPDesk::getBranchId('London HQ');
 
     expect($first)->toBe('br-1')->and($second)->toBe('br-1');

--- a/tests/Feature/BranchesTest.php
+++ b/tests/Feature/BranchesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('returns branches as a Collection', function () {
+    Http::fake(['*api/branches*' => Http::response([
+        ['id' => 'br-1', 'name' => 'London HQ'],
+        ['id' => 'br-2', 'name' => 'Manchester'],
+    ])]);
+
+    $result = TOPDesk::getBranches();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches'));
+});
+
+it('fetches a single branch by id via GET api/branches/id/{id}', function () {
+    Http::fake(['*api/branches/id/*' => Http::response(['id' => 'br-1', 'name' => 'London HQ'])]);
+
+    $result = TOPDesk::getBranch('br-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('br-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches/id/br-1'));
+});
+
+it('creates a branch via POST to api/branches', function () {
+    Http::fake(['*api/branches*' => Http::response(['id' => 'br-new', 'name' => 'Birmingham'])]);
+
+    $result = TOPDesk::createBranch(['name' => 'Birmingham']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('br-new');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/branches'));
+});
+
+it('updates a branch via PATCH to api/branches/id/{id}', function () {
+    Http::fake(['*api/branches/id/*' => Http::response(['id' => 'br-1'])]);
+
+    TOPDesk::updateBranch('br-1', ['phone' => '+44 20 0000 0000']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/branches/id/br-1')
+    );
+});
+
+it('archives a branch via PATCH to api/branches/id/{id}/archive', function () {
+    Http::fake(['*archive*' => Http::response('', 204)]);
+
+    TOPDesk::archiveBranch('br-1');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/branches/id/br-1/archive')
+    );
+});
+
+it('resolves a branch id by name from the lookup endpoint (cached)', function () {
+    Http::fake(['*api/branches/lookup*' => Http::response([['id' => 'br-1', 'name' => 'London HQ']])]);
+
+    $first  = TOPDesk::getBranchId('London HQ');
+    $second = TOPDesk::getBranchId('London HQ');
+
+    expect($first)->toBe('br-1')->and($second)->toBe('br-1');
+    Http::assertSentCount(1);
+});
+
+it('returns branch designations as a cached Collection', function () {
+    Http::fake(['*api/branches/designations*' => Http::response([['id' => 'd-1', 'name' => 'Head Office']])]);
+
+    $result = TOPDesk::getBranchDesignations();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('returns branch building levels as a cached Collection', function () {
+    Http::fake(['*api/branches/buildingLevels*' => Http::response([['id' => 'bl-1', 'name' => 'Ground Floor']])]);
+
+    $result = TOPDesk::getBranchBuildingLevels();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('returns branch attachments as a Collection', function () {
+    Http::fake(['*api/branches/id/br-1/attachments*' => Http::response([['id' => 'att-1', 'fileName' => 'plan.pdf']])]);
+
+    $result = TOPDesk::getBranchAttachments('br-1');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});

--- a/tests/Feature/BranchesTest.php
+++ b/tests/Feature/BranchesTest.php
@@ -89,3 +89,37 @@ it('returns branch attachments as a Collection', function () {
 
     expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
 });
+
+it('unarchives a branch via PATCH to api/branches/id/{id}/unarchive', function () {
+    Http::fake(['*api/branches/id/*/unarchive*' => Http::response(['id' => 'br-1', 'name' => 'London HQ'])]);
+
+    $result = TOPDesk::unarchiveBranch('br-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('br-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/branches/id/br-1/unarchive')
+    );
+});
+
+it('returns branch lookup results as a Collection', function () {
+    Http::fake(['*api/branches/lookup*' => Http::response([
+        ['id' => 'br-1', 'name' => 'London HQ'],
+        ['id' => 'br-2', 'name' => 'Manchester'],
+    ])]);
+
+    $result = TOPDesk::getBranchLookup(['name' => 'London']);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches/lookup'));
+});
+
+it('deletes a branch attachment via DELETE', function () {
+    Http::fake(['*api/branches/id/br-1/attachments/att-1*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteBranchAttachment('br-1', 'att-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'api/branches/id/br-1/attachments/att-1')
+    );
+});

--- a/tests/Feature/CachingTest.php
+++ b/tests/Feature/CachingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+it('setupCacheObject returns the same key it receives', function () {
+    $key = TOPDesk::setupCacheObject('my-cache-key', false);
+
+    expect($key)->toBe('my-cache-key');
+});
+
+it('setupCacheObject clears the cache entry when forgetCache is true', function () {
+    Cache::put('my-cache-key', 'cached-value', 3600);
+
+    TOPDesk::setupCacheObject('my-cache-key', forgetCache: true);
+
+    expect(Cache::has('my-cache-key'))->toBeFalse();
+});
+
+it('setupCacheObject leaves the cache entry intact when forgetCache is false', function () {
+    Cache::put('my-cache-key', 'cached-value', 3600);
+
+    TOPDesk::setupCacheObject('my-cache-key', forgetCache: false);
+
+    expect(Cache::get('my-cache-key'))->toBe('cached-value');
+});
+
+it('setupCacheObject clears the cache when ignore_cache config is true', function () {
+    config(['topdesk.ignore_cache' => true]);
+    Cache::put('my-cache-key', 'cached-value', 3600);
+
+    TOPDesk::setupCacheObject('my-cache-key', forgetCache: false);
+
+    expect(Cache::has('my-cache-key'))->toBeFalse();
+});
+
+it('cached methods make only one HTTP call on repeated invocations', function () {
+    Http::fake(['*api/incidents/priorities*' => Http::response([['id' => 'p-1', 'name' => 'High']])]);
+
+    TOPDesk::getPriorities();
+    TOPDesk::getPriorities();
+    TOPDesk::getPriorities();
+
+    Http::assertSentCount(1);
+});
+
+it('passing forgetCache = true causes the method to re-fetch from the API', function () {
+    Http::fake(['*api/incidents/urgencies*' => Http::response([['id' => 'u-1', 'name' => 'High']])]);
+
+    TOPDesk::getUrgencies();          // 1st call: hits API, caches
+    TOPDesk::getUrgencies(true);     // 2nd call: busts cache, hits API again
+    TOPDesk::getUrgencies();          // 3rd call: hits cache (repopulated by 2nd)
+
+    Http::assertSentCount(2);
+});
+
+it('forgetCache = true on getOperatorGroupId forces a re-fetch', function () {
+    Http::fake(['*api/operatorgroups/lookup*' => Http::response([
+        'results' => [['id' => 'grp-1', 'name' => 'I.T. Services']],
+    ])]);
+
+    TOPDesk::getOperatorGroupId('I.T. Services');
+    TOPDesk::getOperatorGroupId('I.T. Services', forgetCache: true);
+
+    Http::assertSentCount(2);
+});

--- a/tests/Feature/ChangesTest.php
+++ b/tests/Feature/ChangesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('returns all open change activities as a Collection', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response([
+        'results' => [
+            ['id' => 'ca-1', 'title' => 'Change 1'],
+            ['id' => 'ca-2', 'title' => 'Change 2'],
+        ],
+    ])]);
+
+    $result = TOPDesk::allOpenChangeActivities();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorChangeActivities')
+        && str_contains($r->url(), 'open=true')
+        && str_contains($r->url(), 'blocked=false')
+    );
+});
+
+it('returns an empty Collection when open change activities results are null', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response(['results' => null])]);
+
+    $result = TOPDesk::allOpenChangeActivities();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(0);
+});
+
+it('caches allOpenChangeActivities and only calls the API once', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response(['results' => [['id' => 'ca-1']]])]);
+
+    TOPDesk::allOpenChangeActivities();
+    TOPDesk::allOpenChangeActivities();
+
+    Http::assertSentCount(1);
+});
+
+it('returns unassigned waiting change activities filtered by operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid', 'name' => 'I.T. Services']]]),
+        '*api/operatorChangeActivities*' => Http::response(['results' => [['id' => 'ca-2', 'title' => 'Waiting change']]]),
+    ]);
+
+    $result = TOPDesk::unassignedWaitingChangeActivities('I.T. Services');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorChangeActivities')
+        && str_contains($r->url(), 'operator=grp-uuid')
+    );
+});
+
+it('returns waiting change activities by username', function () {
+    Http::fake([
+        '*api/operators*' => Http::response([['id' => 'op-uuid', 'networkLoginName' => 'jsmith']]),
+        '*api/operatorChangeActivities*' => Http::response(['results' => [['id' => 'ca-3', 'title' => 'Server update']]]),
+    ]);
+
+    $result = TOPDesk::waitingChangeActivitiesByUsername('jsmith');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorChangeActivities')
+        && str_contains($r->url(), 'operator=op-uuid')
+    );
+});
+
+it('returns resolved change activities by operator id and time string', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response(['results' => [
+        ['id' => 'ca-4'],
+        ['id' => 'ca-5'],
+    ]])]);
+
+    $result = TOPDesk::resolvedChangeActivitiesByOperatorIdByTime('op-uuid', 'Week');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorChangeActivities')
+        && str_contains($r->url(), 'open=false')
+        && str_contains($r->url(), 'operator=op-uuid')
+    );
+});
+
+it('returns waiting change activities by operator id directly', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response(['results' => [
+        ['id' => 'ca-6'],
+        ['id' => 'ca-7'],
+        ['id' => 'ca-8'],
+    ]])]);
+
+    $result = TOPDesk::waitingChangeActivitiesByOperatorId('op-uuid');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(3);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorChangeActivities')
+        && str_contains($r->url(), 'open=true')
+        && str_contains($r->url(), 'operator=op-uuid')
+    );
+});

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Exceptions\ConfigNotFound;
+
+it('boots successfully when all required config values are present', function () {
+    // The singleton is resolved here; if checkConfig() throws the test fails.
+    expect(fn () => app('topdesk'))->not->toThrow(ConfigNotFound::class);
+});
+
+it('throws ConfigNotFound when the endpoint is null', function () {
+    config(['topdesk.endpoint' => null]);
+    $this->app->forgetInstance('topdesk');
+
+    expect(fn () => $this->app->make('topdesk'))->toThrow(ConfigNotFound::class);
+});
+
+it('throws ConfigNotFound when the endpoint is an empty string', function () {
+    config(['topdesk.endpoint' => '']);
+    $this->app->forgetInstance('topdesk');
+
+    expect(fn () => $this->app->make('topdesk'))->toThrow(ConfigNotFound::class);
+});
+
+it('throws ConfigNotFound when the username is null', function () {
+    config(['topdesk.application_username' => null]);
+    $this->app->forgetInstance('topdesk');
+
+    expect(fn () => $this->app->make('topdesk'))->toThrow(ConfigNotFound::class);
+});
+
+it('throws ConfigNotFound when the password is null', function () {
+    config(['topdesk.application_password' => null]);
+    $this->app->forgetInstance('topdesk');
+
+    expect(fn () => $this->app->make('topdesk'))->toThrow(ConfigNotFound::class);
+});
+
+it('includes the offending config key in the exception message', function () {
+    config(['topdesk.endpoint' => null]);
+    $this->app->forgetInstance('topdesk');
+
+    try {
+        $this->app->make('topdesk');
+        fail('Expected ConfigNotFound');
+    } catch (ConfigNotFound $e) {
+        expect($e->getMessage())->toContain('topdesk.endpoint');
+    }
+});

--- a/tests/Feature/CountsTest.php
+++ b/tests/Feature/CountsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Facades\Http;
+
+// Shared fake helpers used in multiple tests:
+// - operatorgroups/lookup  → resolves a group name to an ID
+// - incidents/statuses     → resolves processing status names to IDs
+// - incidents              → list of incidents for counting
+// - operatorChangeActivities → change activity counts
+
+it('counts tickets logged today for a given operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid', 'name' => 'I.T. Services']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2'], ['id' => 'inc-3']]),
+    ]);
+
+    $count = TOPDesk::countTicketsLoggedtoday('I.T. Services');
+
+    expect($count)->toBe(3);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'grp-uuid')
+        && str_contains($r->url(), 'creationDate')
+    );
+});
+
+it('counts open tickets for a given operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'facilities-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']]),
+    ]);
+
+    $count = TOPDesk::countOpenTickets('Facilities');
+
+    expect($count)->toBe(2);
+});
+
+it('counts tickets due this week for a given operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1']]),
+    ]);
+
+    $count = TOPDesk::countTicketsDueThisWeek('I.T. Services');
+
+    expect($count)->toBe(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'targetDate')
+    );
+});
+
+it('counts breached tickets for a given operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2'], ['id' => 'inc-3'], ['id' => 'inc-4']]),
+    ]);
+
+    $count = TOPDesk::countBreachedTickets('I.T. Services');
+
+    expect($count)->toBe(4);
+});
+
+it('counts tickets by a specific processing status id', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1']]),
+    ]);
+
+    $count = TOPDesk::countByProcessingStatusId('status-uuid', 'I.T. Services');
+
+    expect($count)->toBe(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'processingStatus.id%3D%3Dstatus-uuid')
+            || str_contains($r->url(), 'processingStatus.id==status-uuid')
+    );
+});
+
+it('counts closed tickets for an operator within a time period', function () {
+    Http::fake(['*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']])]);
+
+    $count = TOPDesk::countClosedTicketsByTime('op-uuid', 'week');
+
+    expect($count)->toBe(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'operator.id%3D%3Dop-uuid')
+            || str_contains($r->url(), 'operator.id==op-uuid')
+    );
+});
+
+it('countResolvesByTime delegates to countClosedTicketsByTime', function () {
+    Http::fake(['*api/incidents*' => Http::response([['id' => 'inc-1']])]);
+
+    $count = TOPDesk::countResolvesByTime('op-uuid', 'week');
+
+    expect($count)->toBe(1);
+});
+
+it('counts open tickets for an operator including waiting change activities', function () {
+    Http::fake([
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']]),
+        '*api/operatorChangeActivities*' => Http::response(['results' => [['id' => 'ca-1']]]),
+    ]);
+
+    // 2 open incidents + 1 waiting change activity = 3
+    $count = TOPDesk::countOpenTicketsByOperator('op-uuid');
+
+    expect($count)->toBe(3);
+});
+
+it('counts active tickets for an operator using processing status ids', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'logged-id', 'name' => 'Logged'],
+            ['id' => 'inprogress-id', 'name' => 'In progress'],
+            ['id' => 'updated-id', 'name' => 'Updated by user'],
+        ]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']]),
+    ]);
+
+    $count = TOPDesk::countActiveTicketsbyOperator('op-uuid');
+
+    expect($count)->toBe(2);
+});
+
+it('counts waiting change activities for an operator', function () {
+    Http::fake(['*api/operatorChangeActivities*' => Http::response(['results' => [
+        ['id' => 'ca-1'],
+        ['id' => 'ca-2'],
+    ]])]);
+
+    $count = TOPDesk::countWaitingChangeActivitiesByOperatorId('op-uuid');
+
+    expect($count)->toBe(2);
+});
+
+it('counts tickets by processing status name', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'waiting-id', 'name' => 'Waiting for user'],
+        ]),
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2'], ['id' => 'inc-3']]),
+    ]);
+
+    $count = TOPDesk::countTicketsByStatus('Waiting for user', 'I.T. Services');
+
+    expect($count)->toBe(3);
+});
+
+it('counts unassigned tickets for an operator group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1']]),
+    ]);
+
+    $count = TOPDesk::countUnassignedTickets('I.T. Services');
+
+    expect($count)->toBe(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents'));
+});

--- a/tests/Feature/DepartmentsTest.php
+++ b/tests/Feature/DepartmentsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Facades\Http;
+
+// getDepartments and createDepartment are already tested in GeneralTest.php.
+// This file covers the remaining CRUD operations.
+
+it('updates a department name via PATCH to api/departments/id/{id}', function () {
+    Http::fake(['*api/departments/id/*' => Http::response(['id' => 'dept-1', 'name' => 'Sales'])]);
+
+    $result = TOPDesk::updateDepartment('dept-1', 'Sales');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('dept-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/departments/id/dept-1')
+    );
+});
+
+it('deletes a department via DELETE to api/departments/id/{id}', function () {
+    Http::fake(['*api/departments/id/*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteDepartment('dept-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'api/departments/id/dept-1')
+    );
+});
+
+it('archives a department via PATCH to api/departments/id/{id}/archive', function () {
+    Http::fake(['*api/departments/id/*/archive*' => Http::response('', 204)]);
+
+    $result = TOPDesk::archiveDepartment('dept-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/departments/id/dept-1/archive')
+    );
+});
+
+it('unarchives a department via PATCH to api/departments/id/{id}/unarchive', function () {
+    Http::fake(['*api/departments/id/*/unarchive*' => Http::response(['id' => 'dept-1', 'name' => 'Finance'])]);
+
+    $result = TOPDesk::unarchiveDepartment('dept-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('dept-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/departments/id/dept-1/unarchive')
+    );
+});

--- a/tests/Feature/DeprecatedMethodsTest.php
+++ b/tests/Feature/DeprecatedMethodsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Facades\Http;
+
+// Each deprecated method delegates to countTicketsByStatus(), which in turn
+// resolves the processing status ID and operator group ID before counting.
+// All three HTTP endpoints must be faked per test.
+
+function fakeStatusGroupAndIncidents(string $statusName, int $incidentCount = 2): void
+{
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'status-uuid', 'name' => $statusName],
+        ]),
+        '*api/operatorgroups/lookup*' => Http::response([
+            'results' => [['id' => 'grp-uuid', 'name' => 'I.T. Services']],
+        ]),
+        '*api/incidents*' => Http::response(
+            array_map(fn ($i) => ['id' => "inc-{$i}"], range(1, $incidentCount))
+        ),
+    ]);
+}
+
+it('countWaitingForUserTickets delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('Waiting for user', 3);
+
+    $count = TOPDesk::countWaitingForUserTickets();
+
+    expect($count)->toBe(3);
+});
+
+it('countUpdatedByUserTickets delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('Updated by user', 1);
+
+    $count = TOPDesk::countUpdatedByUserTickets();
+
+    expect($count)->toBe(1);
+});
+
+it('countWaitingForSupplier delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('Waiting for supplier', 5);
+
+    $count = TOPDesk::countWaitingForSupplier();
+
+    expect($count)->toBe(5);
+});
+
+it('countScheduledTickets delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('Scheduled', 2);
+
+    $count = TOPDesk::countScheduledTickets();
+
+    expect($count)->toBe(2);
+});
+
+it('countInProgressTickets delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('In progress', 4);
+
+    $count = TOPDesk::countInProgressTickets();
+
+    expect($count)->toBe(4);
+});
+
+it('countLoggedTickets delegates to countTicketsByStatus', function () {
+    fakeStatusGroupAndIncidents('Logged', 7);
+
+    $count = TOPDesk::countLoggedTickets();
+
+    expect($count)->toBe(7);
+});

--- a/tests/Feature/GeneralTest.php
+++ b/tests/Feature/GeneralTest.php
@@ -49,8 +49,7 @@ it('passes the index and start parameters to the search endpoint', function () {
 
     TOPDesk::search('office', 'branches', 10);
 
-    Http::assertSent(fn ($r) =>
-        str_contains($r->url(), 'index=branches') &&
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'index=branches') &&
         str_contains($r->url(), 'start=10')
     );
 });
@@ -60,7 +59,7 @@ it('returns countries as a cached Collection', function () {
         ['id' => 'c-1', 'name' => 'United Kingdom'],
     ])]);
 
-    $first  = TOPDesk::getCountries();
+    $first = TOPDesk::getCountries();
     $second = TOPDesk::getCountries();
 
     expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(1);

--- a/tests/Feature/GeneralTest.php
+++ b/tests/Feature/GeneralTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('returns the API version as a string', function () {
+    Http::fake(['*api/version*' => Http::response(['version' => '1.2.3'])]);
+
+    $result = TOPDesk::getApiVersion();
+
+    expect($result)->toBeString()->toBe('1.2.3');
+});
+
+it('returns the full product version as an object', function () {
+    Http::fake(['*api/productVersion*' => Http::response(['version' => '10.15.0', 'patchLevel' => '001'])]);
+
+    $result = TOPDesk::getProductVersion();
+
+    expect($result)->toBeObject()->and($result->version)->toBe('10.15.0');
+});
+
+it('returns search results as a Collection', function () {
+    Http::fake(['*api/search*' => Http::response([
+        'results' => [
+            ['id' => 'inc-1', 'number' => 'I-001'],
+            ['id' => 'inc-2', 'number' => 'I-002'],
+        ],
+    ])]);
+
+    $result = TOPDesk::search('printer jam');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/search'));
+});
+
+it('returns an empty Collection when search has no results', function () {
+    Http::fake(['*api/search*' => Http::response(['results' => []])]);
+
+    $result = TOPDesk::search('no results for this query');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(0);
+});
+
+it('passes the index and start parameters to the search endpoint', function () {
+    Http::fake(['*api/search*' => Http::response(['results' => []])]);
+
+    TOPDesk::search('office', 'branches', 10);
+
+    Http::assertSent(fn ($r) =>
+        str_contains($r->url(), 'index=branches') &&
+        str_contains($r->url(), 'start=10')
+    );
+});
+
+it('returns countries as a cached Collection', function () {
+    Http::fake(['*api/countries*' => Http::response([
+        ['id' => 'c-1', 'name' => 'United Kingdom'],
+    ])]);
+
+    $first  = TOPDesk::getCountries();
+    $second = TOPDesk::getCountries();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSentCount(1);
+});
+
+it('returns languages as a cached Collection', function () {
+    Http::fake(['*api/languages*' => Http::response([
+        ['id' => 'lang-1', 'name' => 'English'],
+    ])]);
+
+    $result = TOPDesk::getLanguages();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('fetches departments as a Collection', function () {
+    Http::fake(['*api/departments*' => Http::response([
+        ['id' => 'dept-1', 'name' => 'Finance'],
+    ])]);
+
+    $result = TOPDesk::getDepartments();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('creates a department via POST with just a name', function () {
+    Http::fake(['*api/departments*' => Http::response(['id' => 'dept-new', 'name' => 'Marketing'])]);
+
+    $result = TOPDesk::createDepartment('Marketing');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('dept-new');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_contains($r->url(), 'api/departments'));
+});
+
+it('fetches suppliers as a Collection', function () {
+    Http::fake(['*api/suppliers*' => Http::response([
+        ['id' => 'sup-1', 'name' => 'Dell'],
+    ])]);
+
+    $result = TOPDesk::getSuppliers();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('fetches a single supplier by id', function () {
+    Http::fake(['*api/suppliers/*' => Http::response(['id' => 'sup-1', 'name' => 'Dell'])]);
+
+    $result = TOPDesk::getSupplier('sup-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('sup-1');
+});
+
+it('fetches locations as a Collection', function () {
+    Http::fake(['*api/locations*' => Http::response([
+        ['id' => 'loc-1', 'name' => 'Floor 3'],
+    ])]);
+
+    $result = TOPDesk::getLocations();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('creates a location via POST to api/locations', function () {
+    Http::fake(['*api/locations*' => Http::response(['id' => 'loc-new', 'name' => 'Floor 4'])]);
+
+    $result = TOPDesk::createLocation(['name' => 'Floor 4', 'branch' => ['id' => 'br-1']]);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('loc-new');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/locations'));
+});

--- a/tests/Feature/GeneralTest.php
+++ b/tests/Feature/GeneralTest.php
@@ -131,3 +131,45 @@ it('creates a location via POST to api/locations', function () {
     expect($result)->toBeObject()->and($result->id)->toBe('loc-new');
     Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/locations'));
 });
+
+it('returns service windows as a cached Collection', function () {
+    Http::fake(['*api/serviceWindow/lookup*' => Http::response([
+        ['id' => 'sw-1', 'name' => 'Standard Hours'],
+        ['id' => 'sw-2', 'name' => '24/7'],
+    ])]);
+
+    $first = TOPDesk::getServiceWindows();
+    $second = TOPDesk::getServiceWindows();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSentCount(1); // cached after first call
+});
+
+it('fetches a single service window by id', function () {
+    Http::fake(['*api/serviceWindow/lookup/*' => Http::response(['id' => 'sw-1', 'name' => 'Standard Hours'])]);
+
+    $result = TOPDesk::getServiceWindow('sw-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('sw-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/serviceWindow/lookup/sw-1'));
+});
+
+it('fetches an email by id via GET api/emails/id/{id}', function () {
+    Http::fake(['*api/emails/id/*' => Http::response(['id' => 'email-uuid', 'subject' => 'Test Email'])]);
+
+    $result = TOPDesk::getEmail('email-uuid');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('email-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/emails/id/email-uuid'));
+});
+
+it('deletes an email via DELETE to api/emails/id/{id}', function () {
+    Http::fake(['*api/emails/id/*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteEmail('email-uuid');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'api/emails/id/email-uuid')
+    );
+});

--- a/tests/Feature/HttpLayerTest.php
+++ b/tests/Feature/HttpLayerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+it('dispatches a GET request to the correct URL', function () {
+    Http::fake(['*api/version*' => Http::response(['version' => '1.0'])]);
+
+    TOPDesk::get('api/version');
+
+    Http::assertSent(fn ($r) => $r->method() === 'GET' && str_contains($r->url(), 'api/version'));
+});
+
+it('dispatches a POST request with a JSON body', function () {
+    Http::fake(['*api/incidents*' => Http::response(['id' => 'new-id', 'number' => 'I-001'])]);
+
+    TOPDesk::post('api/incidents', ['briefDescription' => 'Test']);
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_contains($r->url(), 'api/incidents'));
+});
+
+it('dispatches a PUT request', function () {
+    Http::fake(['*' => Http::response(['id' => 'abc'])]);
+
+    TOPDesk::put('api/incidents/id/abc/escalate', ['id' => 'reason-id']);
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_contains($r->url(), 'escalate'));
+});
+
+it('dispatches a PATCH request', function () {
+    Http::fake(['*' => Http::response(['id' => 'abc'])]);
+
+    TOPDesk::patch('api/incidents/id/abc', ['briefDescription' => 'Updated']);
+
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH');
+});
+
+it('dispatches a DELETE request', function () {
+    Http::fake(['*' => Http::response('', 204)]);
+
+    TOPDesk::delete('api/incidents/id/abc/actions/act-id');
+
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE');
+});
+
+it('returns an empty array for 204 No Content responses', function () {
+    Http::fake(['*' => Http::response('', 204)]);
+
+    $result = TOPDesk::delete('api/some/resource/id');
+
+    expect($result)->toBe([]);
+});
+
+it('throws RequestException for 4xx responses', function () {
+    Http::fake(['*' => Http::response(['message' => 'Not found'], 404)]);
+
+    expect(fn () => TOPDesk::get('api/incidents/id/nonexistent'))
+        ->toThrow(RequestException::class);
+});
+
+it('sends basic auth and Accept: application/json on every request', function () {
+    Http::fake(['*' => Http::response(['version' => '1.0'])]);
+
+    TOPDesk::get('api/version');
+
+    Http::assertSent(function ($r) {
+        return $r->hasHeader('Authorization')
+            && $r->header('Accept')[0] === 'application/json'
+            && str_starts_with($r->url(), 'https://company.topdesk.net/tas/');
+    });
+});
+
+it('returns a decoded object from a JSON object response', function () {
+    Http::fake(['*' => Http::response(['id' => 'abc', 'number' => 'I-001'])]);
+
+    $result = TOPDesk::get('api/incidents/id/abc');
+
+    expect($result)->toBeObject()
+        ->and($result->id)->toBe('abc')
+        ->and($result->number)->toBe('I-001');
+});

--- a/tests/Feature/IncidentActionsTest.php
+++ b/tests/Feature/IncidentActionsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+const INCIDENT_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+it('returns the progress trail as a Collection', function () {
+    Http::fake(['*progresstrail*' => Http::response([['id' => 'trail-1', 'memoText' => 'First update']])]);
+
+    $result = TOPDesk::getProgressTrail(INCIDENT_ID);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/progresstrail'));
+});
+
+it('fetches progress trail by incident number', function () {
+    Http::fake(['*progresstrail*' => Http::response([])]);
+
+    TOPDesk::getProgressTrailByNumber('I-001');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/progresstrail'));
+});
+
+it('returns the progress trail count as an integer', function () {
+    Http::fake(['*progresstrail/count*' => Http::response(7)]);
+
+    $result = TOPDesk::getProgressTrailCount(INCIDENT_ID);
+
+    expect($result)->toBeInt()->toBe(7);
+});
+
+it('returns incident actions as a Collection', function () {
+    Http::fake(['*actions*' => Http::response([['id' => 'act-1', 'memoText' => 'Investigated issue']])]);
+
+    $result = TOPDesk::getIncidentActions(INCIDENT_ID);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/actions'));
+});
+
+it('fetches incident actions by incident number', function () {
+    Http::fake(['*actions*' => Http::response([])]);
+
+    TOPDesk::getIncidentActionsByNumber('I-001');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/actions'));
+});
+
+it('fetches a single incident action by id', function () {
+    Http::fake(['*actions/act-1*' => Http::response(['id' => 'act-1', 'memoText' => 'note'])]);
+
+    $result = TOPDesk::getIncidentAction(INCIDENT_ID, 'act-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('act-1');
+});
+
+it('deletes an incident action via DELETE', function () {
+    Http::fake(['*actions/act-1*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteIncidentAction(INCIDENT_ID, 'act-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE' && str_contains($r->url(), 'actions/act-1'));
+});
+
+it('returns incident requests as a Collection', function () {
+    Http::fake(['*requests*' => Http::response([['id' => 'req-1', 'memoText' => 'What is wrong?']])]);
+
+    $result = TOPDesk::getIncidentRequests(INCIDENT_ID);
+
+    expect($result)->toBeInstanceOf(Collection::class);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/requests'));
+});
+
+it('returns time spent entries as a Collection', function () {
+    Http::fake(['*timespent*' => Http::response([['id' => 'ts-1', 'timeSpent' => 30]])]);
+
+    $result = TOPDesk::getTimeSpent(INCIDENT_ID);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/timespent'));
+});
+
+it('registers time spent via POST and returns the entry', function () {
+    Http::fake(['*timespent*' => Http::response(['id' => 'ts-new', 'timeSpent' => 30])]);
+
+    $result = TOPDesk::registerTimeSpent(INCIDENT_ID, ['timeSpent' => 30]);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('ts-new');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_contains($r->url(), 'id/'.INCIDENT_ID.'/timespent'));
+});
+
+it('registers time spent by incident number', function () {
+    Http::fake(['*timespent*' => Http::response(['id' => 'ts-new'])]);
+
+    TOPDesk::registerTimeSpentByNumber('I-001', ['timeSpent' => 15]);
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_contains($r->url(), 'number/I-001/timespent'));
+});
+
+it('escalates an incident by id via PUT', function () {
+    Http::fake(['*escalate*' => Http::response(['id' => INCIDENT_ID])]);
+
+    TOPDesk::escalateIncident(INCIDENT_ID, 'reason-uuid');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PUT' &&
+        str_contains($r->url(), 'id/'.INCIDENT_ID.'/escalate')
+    );
+});
+
+it('escalates an incident by number via PUT', function () {
+    Http::fake(['*escalate*' => Http::response(['number' => 'I-001'])]);
+
+    TOPDesk::escalateIncidentByNumber('I-001', 'reason-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/escalate'));
+});
+
+it('de-escalates an incident by id via PUT', function () {
+    Http::fake(['*deescalate*' => Http::response(['id' => INCIDENT_ID])]);
+
+    TOPDesk::deescalateIncident(INCIDENT_ID, 'reason-uuid');
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_contains($r->url(), 'deescalate'));
+});
+
+it('archives an incident by id via PUT with a reason id', function () {
+    Http::fake(['*archive*' => Http::response(['id' => INCIDENT_ID])]);
+
+    TOPDesk::archiveIncident(INCIDENT_ID, 'reason-uuid');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PUT' &&
+        str_contains($r->url(), 'id/'.INCIDENT_ID.'/archive')
+    );
+});
+
+it('archives an incident by number', function () {
+    Http::fake(['*archive*' => Http::response(['number' => 'I-001'])]);
+
+    TOPDesk::archiveIncidentByNumber('I-001', 'reason-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/archive'));
+});
+
+it('unarchives an incident by id via PUT', function () {
+    Http::fake(['*unarchive*' => Http::response(['id' => INCIDENT_ID])]);
+
+    TOPDesk::unarchiveIncident(INCIDENT_ID);
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_contains($r->url(), 'unarchive'));
+});
+
+it('returns incident attachments as a Collection', function () {
+    Http::fake(['*attachments*' => Http::response([['id' => 'att-1', 'fileName' => 'report.pdf']])]);
+
+    $result = TOPDesk::getIncidentAttachments(INCIDENT_ID);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/attachments'));
+});
+
+it('fetches incident attachments by number', function () {
+    Http::fake(['*attachments*' => Http::response([])]);
+
+    TOPDesk::getIncidentAttachmentsByNumber('I-001');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/attachments'));
+});

--- a/tests/Feature/IncidentActionsTest.php
+++ b/tests/Feature/IncidentActionsTest.php
@@ -170,3 +170,102 @@ it('fetches incident attachments by number', function () {
 
     Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/attachments'));
 });
+
+it('deletes an incident attachment via DELETE', function () {
+    Http::fake(['*attachments/att-1*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteIncidentAttachment(INCIDENT_ID, 'att-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'attachments/att-1')
+    );
+});
+
+it('returns the progress trail count by incident number as an integer', function () {
+    Http::fake(['*progresstrail/count*' => Http::response(3)]);
+
+    $result = TOPDesk::getProgressTrailCountByNumber('I-001');
+
+    expect($result)->toBeInt()->toBe(3);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/progresstrail/count'));
+});
+
+it('returns incident requests by number as a Collection', function () {
+    Http::fake(['*requests*' => Http::response([['id' => 'req-1', 'memoText' => 'Request text']])]);
+
+    $result = TOPDesk::getIncidentRequestsByNumber('I-001');
+
+    expect($result)->toBeInstanceOf(Collection::class);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/requests'));
+});
+
+it('fetches a single incident request by id', function () {
+    Http::fake(['*requests/req-1*' => Http::response(['id' => 'req-1', 'memoText' => 'Original request'])]);
+
+    $result = TOPDesk::getIncidentRequest(INCIDENT_ID, 'req-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('req-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'id/'.INCIDENT_ID.'/requests/req-1'));
+});
+
+it('deletes an incident request via DELETE', function () {
+    Http::fake(['*requests/req-1*' => Http::response('', 204)]);
+
+    $result = TOPDesk::deleteIncidentRequest(INCIDENT_ID, 'req-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), 'id/'.INCIDENT_ID.'/requests/req-1')
+    );
+});
+
+it('returns time spent entries by incident number as a Collection', function () {
+    Http::fake(['*timespent*' => Http::response([['id' => 'ts-1', 'timeSpent' => 45]])]);
+
+    $result = TOPDesk::getTimeSpentByNumber('I-001');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'number/I-001/timespent'));
+});
+
+it('returns time registrations as a Collection', function () {
+    Http::fake(['*timeregistrations*' => Http::response([
+        ['id' => 'tr-1', 'timeSpent' => 60],
+        ['id' => 'tr-2', 'timeSpent' => 30],
+    ])]);
+
+    $result = TOPDesk::getTimeRegistrations();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents/timeregistrations'));
+});
+
+it('fetches a single time registration by id', function () {
+    Http::fake(['*timeregistrations/tr-1*' => Http::response(['id' => 'tr-1', 'timeSpent' => 60])]);
+
+    $result = TOPDesk::getTimeRegistration('tr-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('tr-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents/timeregistrations/tr-1'));
+});
+
+it('de-escalates an incident by number via PUT', function () {
+    Http::fake(['*deescalate*' => Http::response(['number' => 'I-001'])]);
+
+    TOPDesk::deescalateIncidentByNumber('I-001', 'reason-uuid');
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT'
+        && str_contains($r->url(), 'number/I-001/deescalate')
+    );
+});
+
+it('unarchives an incident by number via PUT', function () {
+    Http::fake(['*unarchive*' => Http::response(['number' => 'I-001'])]);
+
+    TOPDesk::unarchiveIncidentByNumber('I-001');
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT'
+        && str_contains($r->url(), 'number/I-001/unarchive')
+    );
+});

--- a/tests/Feature/IncidentActionsTest.php
+++ b/tests/Feature/IncidentActionsTest.php
@@ -107,8 +107,7 @@ it('escalates an incident by id via PUT', function () {
 
     TOPDesk::escalateIncident(INCIDENT_ID, 'reason-uuid');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PUT' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' &&
         str_contains($r->url(), 'id/'.INCIDENT_ID.'/escalate')
     );
 });
@@ -134,8 +133,7 @@ it('archives an incident by id via PUT with a reason id', function () {
 
     TOPDesk::archiveIncident(INCIDENT_ID, 'reason-uuid');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PUT' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' &&
         str_contains($r->url(), 'id/'.INCIDENT_ID.'/archive')
     );
 });

--- a/tests/Feature/IncidentLookupsTest.php
+++ b/tests/Feature/IncidentLookupsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+dataset('incident_lookup_methods', [
+    'call types'           => ['getCallTypes',          'api/incidents/call_types'],
+    'durations'            => ['getDurations',           'api/incidents/durations'],
+    'entry types'          => ['getEntryTypes',          'api/incidents/entry_types'],
+    'impacts'              => ['getImpacts',             'api/incidents/impacts'],
+    'priorities'           => ['getPriorities',          'api/incidents/priorities'],
+    'urgencies'            => ['getUrgencies',           'api/incidents/urgencies'],
+    'closure codes'        => ['getClosureCodes',        'api/incidents/closure_codes'],
+    'escalation reasons'   => ['getEscalationReasons',   'api/incidents/escalation-reasons'],
+    'deescalation reasons' => ['getDeescalationReasons', 'api/incidents/deescalation-reasons'],
+    'time spent reasons'   => ['getTimeSpentReasons',    'api/timespent-reasons'],
+]);
+
+it('returns lookup list as a Collection from the correct endpoint', function (string $method, string $urlPath) {
+    Http::fake(["*{$urlPath}*" => Http::response([['id' => '1', 'name' => 'Test']])]);
+
+    $result = TOPDesk::$method();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), $urlPath));
+})->with('incident_lookup_methods');
+
+it('caches lookup results — HTTP is called only once on repeated calls', function () {
+    Http::fake(['*call_types*' => Http::response([['id' => '1', 'name' => 'Phone']])]);
+
+    TOPDesk::getCallTypes();
+    TOPDesk::getCallTypes();
+
+    Http::assertSentCount(1);
+});
+
+it('re-fetches after the cache is busted with forgetCache = true', function () {
+    Http::fake(['*call_types*' => Http::response([['id' => '1', 'name' => 'Phone']])]);
+
+    TOPDesk::getCallTypes();
+    TOPDesk::getCallTypes(forgetCache: true);
+
+    Http::assertSentCount(2);
+});
+
+it('returns SLAs as a Collection', function () {
+    Http::fake(['*api/incidents/slas*' => Http::response([['id' => 'sla-1', 'name' => '4h fix']])]);
+
+    $result = TOPDesk::getSlas();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('returns SLA services as a Collection', function () {
+    Http::fake(['*api/incidents/slas/services*' => Http::response([['id' => 'svc-1']])]);
+
+    $result = TOPDesk::getSlaServices();
+
+    expect($result)->toBeInstanceOf(Collection::class);
+});
+
+it('returns categories as a Collection', function () {
+    Http::fake(['*api/categories*' => Http::response([
+        ['id' => 'cat-1', 'name' => 'Hardware'],
+        ['id' => 'cat-2', 'name' => 'Software'],
+    ])]);
+
+    $result = TOPDesk::getCategories();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+});

--- a/tests/Feature/IncidentLookupsTest.php
+++ b/tests/Feature/IncidentLookupsTest.php
@@ -7,16 +7,16 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 
 dataset('incident_lookup_methods', [
-    'call types'           => ['getCallTypes',          'api/incidents/call_types'],
-    'durations'            => ['getDurations',           'api/incidents/durations'],
-    'entry types'          => ['getEntryTypes',          'api/incidents/entry_types'],
-    'impacts'              => ['getImpacts',             'api/incidents/impacts'],
-    'priorities'           => ['getPriorities',          'api/incidents/priorities'],
-    'urgencies'            => ['getUrgencies',           'api/incidents/urgencies'],
-    'closure codes'        => ['getClosureCodes',        'api/incidents/closure_codes'],
-    'escalation reasons'   => ['getEscalationReasons',   'api/incidents/escalation-reasons'],
+    'call types' => ['getCallTypes',          'api/incidents/call_types'],
+    'durations' => ['getDurations',           'api/incidents/durations'],
+    'entry types' => ['getEntryTypes',          'api/incidents/entry_types'],
+    'impacts' => ['getImpacts',             'api/incidents/impacts'],
+    'priorities' => ['getPriorities',          'api/incidents/priorities'],
+    'urgencies' => ['getUrgencies',           'api/incidents/urgencies'],
+    'closure codes' => ['getClosureCodes',        'api/incidents/closure_codes'],
+    'escalation reasons' => ['getEscalationReasons',   'api/incidents/escalation-reasons'],
     'deescalation reasons' => ['getDeescalationReasons', 'api/incidents/deescalation-reasons'],
-    'time spent reasons'   => ['getTimeSpentReasons',    'api/timespent-reasons'],
+    'time spent reasons' => ['getTimeSpentReasons',    'api/timespent-reasons'],
 ]);
 
 it('returns lookup list as a Collection from the correct endpoint', function (string $method, string $urlPath) {

--- a/tests/Feature/IncidentsTest.php
+++ b/tests/Feature/IncidentsTest.php
@@ -25,8 +25,7 @@ it('merges caller options into the incident list request', function () {
 
     TOPDesk::getListOfIncidents(['page_size' => 25, 'status' => 'firstLine']);
 
-    Http::assertSent(fn ($r) =>
-        str_contains($r->url(), 'page_size=25') &&
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'page_size=25') &&
         str_contains($r->url(), 'status=firstLine')
     );
 });
@@ -69,8 +68,7 @@ it('updates an incident by uuid via PATCH to api/incidents/id/{id}', function ()
 
     TOPDesk::updateIncident($id, ['briefDescription' => 'Updated']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), "api/incidents/id/{$id}")
     );
 });
@@ -80,8 +78,7 @@ it('updates an incident by number via PATCH to api/incidents/number/{number}', f
 
     TOPDesk::updateIncidentByNumber('I-001', ['briefDescription' => 'Updated']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/incidents/number/I-001')
     );
 });

--- a/tests/Feature/IncidentsTest.php
+++ b/tests/Feature/IncidentsTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
 use FredBradley\TOPDesk\Exceptions\OperatorGroupNotFound;
 use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
 use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 
@@ -137,6 +139,18 @@ it('throws OperatorNotFound when the operator lookup returns a null body', funct
         ->toThrow(OperatorNotFound::class);
 });
 
+it('returns a Collection when getOperatorByUsername finds multiple matches', function () {
+    Http::fake(['*api/operators*' => Http::response([
+        ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+        ['id' => 'op-2', 'networkLoginName' => 'jsmith2'],
+    ])]);
+
+    $result = TOPDesk::getOperatorByUsername('jsmith');
+
+    // count > 1 returns the collection directly
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+});
+
 it('counts incidents matching a FIQL query', function () {
     Http::fake(['*api/incidents*' => Http::response([
         ['id' => 'inc-1'],
@@ -165,4 +179,118 @@ it('resolves an archive reason id by name', function () {
     ])]);
 
     expect(TOPDesk::getArchiveReasonId('Duplicate'))->toBe('reason-dup');
+});
+
+it('getIncidentbyNumber (deprecated) delegates to getIncident by number', function () {
+    Http::fake(['*api/incidents/number/*' => Http::response(['id' => 'inc-abc', 'number' => 'I-2024-001'])]);
+
+    $result = TOPDesk::getIncidentbyNumber('I-2024-001');
+
+    expect($result)->toBeObject()->and($result->number)->toBe('I-2024-001');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents/number/I-2024-001'));
+});
+
+it('returns a processing status object by name', function () {
+    Http::fake(['*api/incidents/statuses*' => Http::response([
+        ['id' => 'status-open', 'name' => 'Open'],
+        ['id' => 'status-closed', 'name' => 'Closed'],
+    ])]);
+
+    $status = TOPDesk::getProcessingStatus('Open');
+
+    expect($status)->toBeArray()->toHaveKey('id');
+    expect($status['id'])->toBe('status-open');
+});
+
+it('throws an exception when a processing status name is not found', function () {
+    Http::fake(['*api/incidents/statuses*' => Http::response([
+        ['id' => 'status-open', 'name' => 'Open'],
+    ])]);
+
+    expect(fn () => TOPDesk::getProcessingStatus('Nonexistent'))
+        ->toThrow(Exception::class, 'Status Not Found');
+});
+
+it('returns open incidents for an operator group as a Collection (default Open status)', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'status-closed', 'name' => 'Closed'],
+        ]),
+        '*api/incidents*' => Http::response([
+            ['id' => 'inc-1', 'creationDate' => now()->toIso8601String(), 'targetDate' => null],
+            ['id' => 'inc-2', 'creationDate' => now()->toIso8601String(), 'targetDate' => null],
+        ]),
+    ]);
+
+    $result = TOPDesk::getOpenIncidentsByOperatorGroupId('grp-uuid');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'grp-uuid')
+    );
+});
+
+it('parses targetDate as a Carbon instance when it is not null', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([['id' => 'status-closed', 'name' => 'Closed']]),
+        '*api/incidents*' => Http::response([
+            [
+                'id' => 'inc-1',
+                'creationDate' => now()->toIso8601String(),
+                'targetDate' => now()->addDays(3)->toIso8601String(),
+            ],
+        ]),
+    ]);
+
+    $result = TOPDesk::getOpenIncidentsByOperatorGroupId('grp-uuid');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    expect($result->first()->targetDate)->toBeInstanceOf(Carbon::class);
+});
+
+it('re-throws RequestException from getOpenIncidentsByOperatorGroupId when the API returns an error', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([['id' => 'status-closed', 'name' => 'Closed']]),
+        '*api/incidents*' => Http::response(['error' => 'Server Error'], 500),
+    ]);
+
+    expect(fn () => TOPDesk::getOpenIncidentsByOperatorGroupId('grp-uuid'))
+        ->toThrow(RequestException::class);
+});
+
+it('returns open incidents for an operator group with a specific processing status', function () {
+    Http::fake([
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'status-logged', 'name' => 'Logged'],
+        ]),
+        '*api/incidents*' => Http::response([
+            ['id' => 'inc-1', 'creationDate' => now()->toIso8601String(), 'targetDate' => null],
+        ]),
+    ]);
+
+    $result = TOPDesk::getOpenIncidentsByOperatorGroupId('grp-uuid', 'Logged');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('deprecatedgetOpenIncidentsByOperatorGroupId returns incidents with null processing status', function () {
+    Http::fake(['*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']])]);
+
+    $result = TOPDesk::deprecatedgetOpenIncidentsByOperatorGroupId('grp-uuid');
+
+    expect($result)->toBeArray();
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'closed%3D%3Dfalse') || str_contains($r->url(), 'closed==false')
+    );
+});
+
+it('deprecatedgetOpenIncidentsByOperatorGroupId filters by processing status name', function () {
+    Http::fake(['*api/incidents*' => Http::response([['id' => 'inc-1']])]);
+
+    $result = TOPDesk::deprecatedgetOpenIncidentsByOperatorGroupId('grp-uuid', 'Logged', ['id', 'number']);
+
+    expect($result)->toBeArray();
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents')
+        && str_contains($r->url(), 'Logged')
+    );
 });

--- a/tests/Feature/IncidentsTest.php
+++ b/tests/Feature/IncidentsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Exceptions\OperatorGroupNotFound;
+use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('fetches a list of incidents with start=0 and page_size=100 by default', function () {
+    Http::fake(['*api/incidents*' => Http::response([['id' => 'inc-1']])]);
+
+    TOPDesk::getListOfIncidents();
+
+    Http::assertSent(function ($r) {
+        return str_contains($r->url(), 'api/incidents')
+            && str_contains($r->url(), 'start=0')
+            && str_contains($r->url(), 'page_size=100');
+    });
+});
+
+it('merges caller options into the incident list request', function () {
+    Http::fake(['*api/incidents*' => Http::response([])]);
+
+    TOPDesk::getListOfIncidents(['page_size' => 25, 'status' => 'firstLine']);
+
+    Http::assertSent(fn ($r) =>
+        str_contains($r->url(), 'page_size=25') &&
+        str_contains($r->url(), 'status=firstLine')
+    );
+});
+
+it('fetches an incident by UUID using the /id/ endpoint', function () {
+    $uuid = '550e8400-e29b-41d4-a716-446655440000';
+    Http::fake(['*api/incidents/id/*' => Http::response(['id' => $uuid, 'number' => 'I-001'])]);
+
+    $result = TOPDesk::getIncident($uuid);
+
+    expect($result)->toBeObject()->and($result->id)->toBe($uuid);
+    Http::assertSent(fn ($r) => str_contains($r->url(), "api/incidents/id/{$uuid}"));
+});
+
+it('fetches an incident by number using the /number/ endpoint', function () {
+    Http::fake(['*api/incidents/number/*' => Http::response(['id' => 'abc', 'number' => 'I-2024-001'])]);
+
+    $result = TOPDesk::getIncident('I-2024-001');
+
+    expect($result->number)->toBe('I-2024-001');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/incidents/number/I-2024-001'));
+});
+
+it('creates an incident via POST to api/incidents', function () {
+    Http::fake(['*api/incidents*' => Http::response(['id' => 'new-id', 'number' => 'I-999'])]);
+
+    $result = TOPDesk::createIncident(['briefDescription' => 'Printer broken']);
+
+    expect($result)->toBeObject()->and($result->number)->toBe('I-999');
+    Http::assertSent(function ($r) {
+        $path = parse_url($r->url(), PHP_URL_PATH);
+
+        return $r->method() === 'POST' && str_ends_with($path, '/api/incidents');
+    });
+});
+
+it('updates an incident by uuid via PATCH to api/incidents/id/{id}', function () {
+    $id = 'inc-uuid-123';
+    Http::fake(['*api/incidents/id/*' => Http::response(['id' => $id])]);
+
+    TOPDesk::updateIncident($id, ['briefDescription' => 'Updated']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), "api/incidents/id/{$id}")
+    );
+});
+
+it('updates an incident by number via PATCH to api/incidents/number/{number}', function () {
+    Http::fake(['*api/incidents/number/*' => Http::response(['number' => 'I-001'])]);
+
+    TOPDesk::updateIncidentByNumber('I-001', ['briefDescription' => 'Updated']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/incidents/number/I-001')
+    );
+});
+
+it('returns all processing statuses as a Collection', function () {
+    Http::fake(['*api/incidents/statuses*' => Http::response([
+        ['id' => 'status-1', 'name' => 'Open'],
+        ['id' => 'status-2', 'name' => 'Closed'],
+    ])]);
+
+    $result = TOPDesk::getAllProcessingStatuses();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+});
+
+it('resolves a processing status id by its name', function () {
+    Http::fake(['*api/incidents/statuses*' => Http::response([
+        ['id' => 'status-open', 'name' => 'Open'],
+        ['id' => 'status-closed', 'name' => 'Closed'],
+    ])]);
+
+    expect(TOPDesk::getProcessingStatusId('Open'))->toBe('status-open');
+    expect(TOPDesk::getProcessingStatusId('Closed'))->toBe('status-closed');
+});
+
+it('resolves an operator group id by display name', function () {
+    Http::fake(['*api/operatorgroups/lookup*' => Http::response([
+        'results' => [['id' => 'group-uuid', 'name' => 'I.T. Services']],
+    ])]);
+
+    expect(TOPDesk::getOperatorGroupId('I.T. Services'))->toBe('group-uuid');
+});
+
+it('throws OperatorGroupNotFound when the group name does not exist', function () {
+    Http::fake(['*api/operatorgroups/lookup*' => Http::response(['results' => []])]);
+
+    expect(fn () => TOPDesk::getOperatorGroupId('Nonexistent'))
+        ->toThrow(OperatorGroupNotFound::class);
+});
+
+it('returns a single operator as stdClass when found by username', function () {
+    Http::fake(['*api/operators*' => Http::response([
+        ['id' => 'op-uuid', 'networkLoginName' => 'jsmith'],
+    ])]);
+
+    $result = TOPDesk::getOperatorByUsername('jsmith');
+
+    expect($result)->toBeObject()->and($result->networkLoginName)->toBe('jsmith');
+});
+
+it('throws OperatorNotFound when the operator lookup returns a null body', function () {
+    // TOPdesk returns JSON null when no operator matches; object() returns null.
+    Http::fake(['*api/operators*' => Http::response('null', 200, ['Content-Type' => 'application/json'])]);
+
+    expect(fn () => TOPDesk::getOperatorByUsername('nobody'))
+        ->toThrow(OperatorNotFound::class);
+});
+
+it('counts incidents matching a FIQL query', function () {
+    Http::fake(['*api/incidents*' => Http::response([
+        ['id' => 'inc-1'],
+        ['id' => 'inc-2'],
+    ])]);
+
+    $count = TOPDesk::getNumIncidents('closed==false');
+
+    expect($count)->toBe(2);
+});
+
+it('returns archive reasons as a Collection', function () {
+    Http::fake(['*api/archiving-reasons*' => Http::response([
+        ['id' => 'reason-1', 'name' => 'Duplicate'],
+    ])]);
+
+    $reasons = TOPDesk::getArchiveReasons();
+
+    expect($reasons)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('resolves an archive reason id by name', function () {
+    Http::fake(['*api/archiving-reasons*' => Http::response([
+        ['id' => 'reason-dup', 'name' => 'Duplicate'],
+        ['id' => 'reason-err', 'name' => 'Logged in error'],
+    ])]);
+
+    expect(TOPDesk::getArchiveReasonId('Duplicate'))->toBe('reason-dup');
+});

--- a/tests/Feature/LocationsTest.php
+++ b/tests/Feature/LocationsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+// getLocations and createLocation are already tested in GeneralTest.php.
+// This file covers the remaining operations.
+
+it('fetches a single location by id via GET api/locations/id/{id}', function () {
+    Http::fake(['*api/locations/id/*' => Http::response(['id' => 'loc-1', 'name' => 'Server Room'])]);
+
+    $result = TOPDesk::getLocation('loc-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('loc-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/locations/id/loc-1'));
+});
+
+it('updates a location via PATCH to api/locations/id/{id}', function () {
+    Http::fake(['*api/locations/id/*' => Http::response(['id' => 'loc-1', 'name' => 'Updated Room'])]);
+
+    $result = TOPDesk::updateLocation('loc-1', ['name' => 'Updated Room']);
+
+    expect($result)->toBeObject()->and($result->name)->toBe('Updated Room');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/locations/id/loc-1')
+    );
+});
+
+it('archives a location via PATCH to api/locations/id/{id}/archive', function () {
+    Http::fake(['*api/locations/id/*/archive*' => Http::response('', 204)]);
+
+    $result = TOPDesk::archiveLocation('loc-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/locations/id/loc-1/archive')
+    );
+});
+
+it('unarchives a location via PATCH to api/locations/id/{id}/unarchive', function () {
+    Http::fake(['*api/locations/id/*/unarchive*' => Http::response(['id' => 'loc-1', 'name' => 'Server Room'])]);
+
+    $result = TOPDesk::unarchiveLocation('loc-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('loc-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/locations/id/loc-1/unarchive')
+    );
+});
+
+it('returns location lookup results as a Collection', function () {
+    Http::fake(['*api/locations/lookup*' => Http::response([
+        ['id' => 'loc-1', 'name' => 'Server Room'],
+        ['id' => 'loc-2', 'name' => 'Meeting Room A'],
+    ])]);
+
+    $result = TOPDesk::getLocationLookup(['name' => 'Room']);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/locations/lookup'));
+});
+
+it('returns location types as a cached Collection', function () {
+    Http::fake(['*api/locations/types*' => Http::response([
+        ['id' => 'type-1', 'name' => 'Classroom'],
+        ['id' => 'type-2', 'name' => 'Office'],
+    ])]);
+
+    $first = TOPDesk::getLocationTypes();
+    $second = TOPDesk::getLocationTypes();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSentCount(1); // cached after first call
+});
+
+it('returns location statuses as a cached Collection', function () {
+    Http::fake(['*api/locations/statuses*' => Http::response([
+        ['id' => 'status-1', 'name' => 'Available'],
+    ])]);
+
+    $result = TOPDesk::getLocationStatuses();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('returns building zones as a cached Collection', function () {
+    Http::fake(['*api/locations/building_zones*' => Http::response([
+        ['id' => 'zone-1', 'name' => 'North Wing'],
+    ])]);
+
+    $first = TOPDesk::getBuildingZones();
+    $second = TOPDesk::getBuildingZones();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSentCount(1);
+});

--- a/tests/Feature/OperatorStatsTest.php
+++ b/tests/Feature/OperatorStatsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('returns operators in a group as a Collection', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid', 'name' => 'I.T. Services']]]),
+        '*api/operators*' => Http::response([
+            ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+            ['id' => 'op-2', 'networkLoginName' => 'bjones'],
+        ]),
+    ]);
+
+    $result = TOPDesk::getOperatorsByOperatorGroup('I.T. Services');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operators')
+        && str_contains($r->url(), 'grp-uuid')
+    );
+});
+
+it('caches operator group members and hits API only once', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([['id' => 'op-1', 'networkLoginName' => 'jsmith']]),
+    ]);
+
+    TOPDesk::getOperatorsByOperatorGroup('I.T. Services');
+    TOPDesk::getOperatorsByOperatorGroup('I.T. Services');
+
+    Http::assertSentCount(2); // 1 for lookup + 1 for operators (both cached after first)
+});
+
+it('returns open ticket counts keyed by login name', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([['id' => 'op-1', 'networkLoginName' => 'jsmith']]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1'], ['id' => 'inc-2']]),
+        '*api/operatorChangeActivities*' => Http::response(['results' => []]),
+    ]);
+
+    $result = TOPDesk::openCountsForOperatorGroup('I.T. Services');
+
+    expect($result)->toBeArray()->toHaveKey('jsmith');
+    expect($result['jsmith'])->toBe(2);
+});
+
+it('excludes specified usernames from open counts', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([
+            ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+            ['id' => 'op-2', 'networkLoginName' => 'bjones'],
+        ]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1']]),
+        '*api/operatorChangeActivities*' => Http::response(['results' => []]),
+    ]);
+
+    $result = TOPDesk::openCountsForOperatorGroup('I.T. Services', ['bjones']);
+
+    expect($result)->toBeArray()->toHaveKey('jsmith')->not->toHaveKey('bjones');
+});
+
+it('returns active ticket counts keyed by login name', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([['id' => 'op-1', 'networkLoginName' => 'jsmith']]),
+        '*api/incidents/statuses*' => Http::response([
+            ['id' => 'logged-id', 'name' => 'Logged'],
+            ['id' => 'inprogress-id', 'name' => 'In progress'],
+            ['id' => 'updated-id', 'name' => 'Updated by user'],
+        ]),
+        '*api/incidents*' => Http::response([['id' => 'inc-1']]),
+    ]);
+
+    $result = TOPDesk::activeCountsForOperatorGroup('I.T. Services');
+
+    expect($result)->toBeArray()->toHaveKey('jsmith');
+    expect($result['jsmith'])->toBe(1);
+});
+
+it('resolveCountsForOperatorGroup delegates to closedTicketCountsForOperatorGroup', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([['id' => 'op-1', 'networkLoginName' => 'jsmith']]),
+        '*api/incidents*' => Http::response([
+            ['id' => 'inc-1', 'closed' => true, 'closedDate' => now()->toIso8601String()],
+        ]),
+    ]);
+
+    $result = TOPDesk::resolveCountsForOperatorGroup('I.T. Services');
+
+    expect($result)->toBeArray()->toHaveKey('jsmith');
+});
+
+it('returns closed ticket counts for all operators in a group', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([
+            ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+            ['id' => 'op-2', 'networkLoginName' => 'BJONES'],
+        ]),
+        '*api/incidents*' => Http::response([
+            ['id' => 'inc-1', 'closed' => true, 'closedDate' => now()->toIso8601String()],
+            ['id' => 'inc-2', 'closed' => false, 'closedDate' => null],
+        ]),
+    ]);
+
+    $result = TOPDesk::closedTicketCountsForOperatorGroup('I.T. Services');
+
+    expect($result)->toBeArray()
+        ->toHaveKey('jsmith')
+        ->toHaveKey('BJONES');
+});
+
+it('excludes ignored usernames case-insensitively from closed counts', function () {
+    Http::fake([
+        '*api/operatorgroups/lookup*' => Http::response(['results' => [['id' => 'grp-uuid']]]),
+        '*api/operators*' => Http::response([
+            ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+            ['id' => 'op-2', 'networkLoginName' => 'BJONES'],
+        ]),
+        '*api/incidents*' => Http::response([]),
+    ]);
+
+    // Ignore 'bjones' (lowercase) should exclude 'BJONES' (uppercase) too
+    $result = TOPDesk::closedTicketCountsForOperatorGroup('I.T. Services', ['bjones']);
+
+    expect($result)->toBeArray()->toHaveKey('jsmith')->not->toHaveKey('BJONES');
+});
+
+it('getResolvedIncidentsForOperator delegates to getClosedIncidentsForOperator', function () {
+    Http::fake(['*api/incidents*' => Http::response([
+        ['id' => 'inc-1', 'closed' => true, 'closedDate' => now()->toIso8601String()],
+    ])]);
+
+    $result = TOPDesk::getResolvedIncidentsForOperator('op-uuid');
+
+    expect($result)->toBeArray()->toHaveKeys(['closed_day', 'closed_week', 'closed_month', 'closed_total', 'open']);
+});
+
+it('returns closed incidents breakdown for an operator', function () {
+    Http::fake(['*api/incidents*' => Http::response([
+        ['id' => 'inc-1', 'closed' => true, 'closedDate' => now()->toIso8601String()],
+        ['id' => 'inc-2', 'closed' => true, 'closedDate' => now()->subDays(2)->toIso8601String()],
+        ['id' => 'inc-3', 'closed' => false, 'closedDate' => null],
+    ])]);
+
+    $result = TOPDesk::getClosedIncidentsForOperator('op-uuid');
+
+    expect($result)->toBeArray()
+        ->toHaveKeys(['closed_day', 'closed_week', 'closed_month', 'closed_total', 'open']);
+    expect($result['closed_total'])->toBe(2);
+    expect($result['open'])->toBe(1);
+});
+
+it('getResolvedTicketsForOperator is an alias for getClosedIncidentsForOperator', function () {
+    Http::fake(['*api/incidents*' => Http::response([
+        ['id' => 'inc-1', 'closed' => true, 'closedDate' => now()->toIso8601String()],
+    ])]);
+
+    $result = TOPDesk::getResolvedTicketsForOperator('op-uuid');
+
+    expect($result)->toBeArray()->toHaveKey('closed_total');
+    expect($result['closed_total'])->toBe(1);
+});

--- a/tests/Feature/OperatorsTest.php
+++ b/tests/Feature/OperatorsTest.php
@@ -117,3 +117,69 @@ it('returns operators in a group as a Collection', function () {
 
     expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
 });
+
+it('unarchives an operator via PATCH to api/operators/id/{id}/unarchive', function () {
+    Http::fake(['*api/operators/id/op-uuid/unarchive*' => Http::response(['id' => 'op-uuid'])]);
+
+    TOPDesk::unarchiveOperator('op-uuid');
+
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/operators/id/op-uuid/unarchive')
+    );
+});
+
+it('returns operator lookup results as a Collection', function () {
+    Http::fake(['*api/operators/lookup*' => Http::response([
+        ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+        ['id' => 'op-2', 'networkLoginName' => 'bjones'],
+    ])]);
+
+    $result = TOPDesk::getOperatorLookup(['name' => 'smith']);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operators/lookup'));
+});
+
+it('updates an operator group via PATCH to api/operatorgroups/id/{id}', function () {
+    Http::fake(['*api/operatorgroups/id/grp-1*' => Http::response(['id' => 'grp-1', 'groupName' => 'Updated Group'])]);
+
+    $result = TOPDesk::updateOperatorGroup('grp-1', ['groupName' => 'Updated Group']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('grp-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/operatorgroups/id/grp-1')
+    );
+});
+
+it('archives an operator group via PATCH to api/operatorgroups/id/{id}/archive', function () {
+    Http::fake(['*api/operatorgroups/id/grp-1/archive*' => Http::response('', 204)]);
+
+    $result = TOPDesk::archiveOperatorGroup('grp-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/operatorgroups/id/grp-1/archive')
+    );
+});
+
+it('unarchives an operator group via PATCH to api/operatorgroups/id/{id}/unarchive', function () {
+    Http::fake(['*api/operatorgroups/id/grp-1/unarchive*' => Http::response(['id' => 'grp-1'])]);
+
+    $result = TOPDesk::unarchiveOperatorGroup('grp-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('grp-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/operatorgroups/id/grp-1/unarchive')
+    );
+});
+
+it('returns operator group lookup results as a Collection', function () {
+    Http::fake(['*api/operatorgroups/lookup*' => Http::response([
+        'results' => [['id' => 'grp-1', 'name' => 'I.T. Services']],
+    ])]);
+
+    $result = TOPDesk::getOperatorGroupLookup(['name' => 'I.T.']);
+
+    expect($result)->toBeInstanceOf(Collection::class);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorgroups/lookup'));
+});

--- a/tests/Feature/OperatorsTest.php
+++ b/tests/Feature/OperatorsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('fetches an operator by id via GET api/operators/id/{id}', function () {
+    Http::fake(['*api/operators/id/*' => Http::response(['id' => 'op-uuid', 'surName' => 'Smith'])]);
+
+    $result = TOPDesk::getOperatorById('op-uuid');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('op-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operators/id/op-uuid'));
+});
+
+it('sends a fields query param when specific fields are requested', function () {
+    Http::fake(['*api/operators/id/*' => Http::response(['id' => 'op-uuid', 'email' => 'op@example.com'])]);
+
+    TOPDesk::getOperatorById('op-uuid', ['id', 'email']);
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'fields=id%2Cemail') || str_contains($r->url(), 'fields=id,email'));
+});
+
+it('creates an operator via POST to api/operators', function () {
+    Http::fake(['*api/operators*' => Http::response(['id' => 'new-op', 'surName' => 'Doe'])]);
+
+    $result = TOPDesk::createOperator(['surName' => 'Doe', 'firstName' => 'Jane']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-op');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/operators'));
+});
+
+it('updates an operator via PATCH to api/operators/id/{id}', function () {
+    Http::fake(['*api/operators/id/*' => Http::response(['id' => 'op-uuid'])]);
+
+    TOPDesk::updateOperator('op-uuid', ['phoneNumber' => '+44 1234 000000']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/operators/id/op-uuid')
+    );
+});
+
+it('archives an operator via PATCH to api/operators/id/{id}/archive', function () {
+    Http::fake(['*archive*' => Http::response('', 204)]);
+
+    TOPDesk::archiveOperator('op-uuid');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/operators/id/op-uuid/archive')
+    );
+});
+
+it('fetches the current operator via GET api/operators/current', function () {
+    Http::fake(['*api/operators/current*' => Http::response(['id' => 'me-uuid', 'surName' => 'Bradley'])]);
+
+    $result = TOPDesk::getCurrentOperator();
+
+    expect($result)->toBeObject()->and($result->id)->toBe('me-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operators/current'));
+});
+
+it('returns the current operator id as a string', function () {
+    Http::fake(['*api/operators/current/id*' => Http::response('"me-uuid"')]);
+
+    $result = TOPDesk::getCurrentOperatorId();
+
+    expect($result)->toBe('me-uuid');
+});
+
+it('returns operator groups as a Collection', function () {
+    Http::fake(['*api/operatorgroups*' => Http::response([
+        ['id' => 'grp-1', 'groupName' => 'I.T. Services'],
+    ])]);
+
+    $result = TOPDesk::getOperatorGroups();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('fetches a single operator group by id', function () {
+    Http::fake(['*api/operatorgroups/id/*' => Http::response(['id' => 'grp-1', 'groupName' => 'I.T. Services'])]);
+
+    $result = TOPDesk::getOperatorGroupById('grp-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('grp-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorgroups/id/grp-1'));
+});
+
+it('creates an operator group via POST', function () {
+    Http::fake(['*api/operatorgroups*' => Http::response(['id' => 'new-grp', 'groupName' => 'Networking'])]);
+
+    $result = TOPDesk::createOperatorGroup(['groupName' => 'Networking']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-grp');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/operatorgroups'));
+});
+
+it('returns permission groups as a cached Collection', function () {
+    Http::fake(['*api/permissiongroups*' => Http::response([['id' => 'perm-1', 'name' => 'Read-only']])]);
+
+    $first  = TOPDesk::getPermissionGroups();
+    $second = TOPDesk::getPermissionGroups();
+
+    expect($first)->toBeInstanceOf(Collection::class);
+    expect($second)->toBeInstanceOf(Collection::class);
+    Http::assertSentCount(1); // cached after first call
+});
+
+it('returns operators in a group as a Collection', function () {
+    Http::fake(['*api/operatorgroups/id/grp-1/operators*' => Http::response([
+        ['id' => 'op-1', 'networkLoginName' => 'jsmith'],
+    ])]);
+
+    $result = TOPDesk::getOperatorGroupOperators('grp-1');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});

--- a/tests/Feature/OperatorsTest.php
+++ b/tests/Feature/OperatorsTest.php
@@ -37,8 +37,7 @@ it('updates an operator via PATCH to api/operators/id/{id}', function () {
 
     TOPDesk::updateOperator('op-uuid', ['phoneNumber' => '+44 1234 000000']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/operators/id/op-uuid')
     );
 });
@@ -48,8 +47,7 @@ it('archives an operator via PATCH to api/operators/id/{id}/archive', function (
 
     TOPDesk::archiveOperator('op-uuid');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/operators/id/op-uuid/archive')
     );
 });
@@ -102,7 +100,7 @@ it('creates an operator group via POST', function () {
 it('returns permission groups as a cached Collection', function () {
     Http::fake(['*api/permissiongroups*' => Http::response([['id' => 'perm-1', 'name' => 'Read-only']])]);
 
-    $first  = TOPDesk::getPermissionGroups();
+    $first = TOPDesk::getPermissionGroups();
     $second = TOPDesk::getPermissionGroups();
 
     expect($first)->toBeInstanceOf(Collection::class);

--- a/tests/Feature/PersonsTest.php
+++ b/tests/Feature/PersonsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Exceptions\PersonNotFound;
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+it('returns a person as stdClass when found by username', function () {
+    Http::fake(['*api/persons*' => Http::response([
+        ['id' => 'person-uuid', 'surName' => 'Smith', 'networkLoginName' => 'jsmith'],
+    ])]);
+
+    $result = TOPDesk::getPersonByUsername('jsmith');
+
+    expect($result)->toBeObject()
+        ->and($result->networkLoginName)->toBe('jsmith')
+        ->and($result->surName)->toBe('Smith');
+});
+
+it('throws PersonNotFound when the username returns an empty result', function () {
+    Http::fake(['*api/persons*' => Http::response([])]);
+
+    expect(fn () => TOPDesk::getPersonByUsername('nobody'))
+        ->toThrow(PersonNotFound::class);
+});
+
+it('fetches a person by UUID via GET api/persons/{id}', function () {
+    Http::fake(['*api/persons/*' => Http::response(['id' => 'person-uuid', 'surName' => 'Doe'])]);
+
+    $result = TOPDesk::getPersonById('person-uuid');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('person-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persons/person-uuid'));
+});
+
+it('creates a person via POST to api/persons', function () {
+    Http::fake(['*api/persons*' => Http::response(['id' => 'new-person', 'surName' => 'Jones'])]);
+
+    $result = TOPDesk::createPerson(['surName' => 'Jones', 'firstName' => 'Dave']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-person');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with(parse_url($r->url(), PHP_URL_PATH), '/api/persons'));
+});
+
+it('updates a person via PATCH to api/persons/{id}', function () {
+    Http::fake(['*api/persons/*' => Http::response(['id' => 'person-uuid'])]);
+
+    TOPDesk::updatePerson('person-uuid', ['phoneNumber' => '+44 1234 567890']);
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/persons/person-uuid')
+    );
+});
+
+it('archives a person via PATCH to api/persons/id/{id}/archive', function () {
+    Http::fake(['*archive*' => Http::response('', 204)]);
+
+    TOPDesk::archivePerson('person-uuid');
+
+    Http::assertSent(fn ($r) =>
+        $r->method() === 'PATCH' &&
+        str_contains($r->url(), 'api/persons/id/person-uuid/archive')
+    );
+});
+
+it('unarchives a person via PATCH to api/persons/id/{id}/unarchive', function () {
+    Http::fake(['*unarchive*' => Http::response('', 204)]);
+
+    TOPDesk::unarchivePerson('person-uuid');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'unarchive'));
+});
+
+it('fetches the current person via GET api/persons/current', function () {
+    Http::fake(['*api/persons/current*' => Http::response(['id' => 'me-uuid', 'surName' => 'Bradley'])]);
+
+    $result = TOPDesk::getCurrentPerson();
+
+    expect($result)->toBeObject()->and($result->id)->toBe('me-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persons/current'));
+});
+
+it('returns the person count as an integer', function () {
+    Http::fake(['*api/persons/count*' => Http::response(42)]);
+
+    $result = TOPDesk::getPersonCount();
+
+    expect($result)->toBeInt()->toBe(42);
+});
+
+it('returns person groups as a Collection', function () {
+    Http::fake(['*api/persongroups*' => Http::response([
+        ['id' => 'pg-1', 'groupName' => 'Finance'],
+        ['id' => 'pg-2', 'groupName' => 'IT'],
+    ])]);
+
+    $result = TOPDesk::getPersonGroups();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+});
+
+it('fetches a single person group by id', function () {
+    Http::fake(['*api/persongroups/pg-1*' => Http::response(['id' => 'pg-1', 'groupName' => 'Finance'])]);
+
+    $result = TOPDesk::getPersonGroup('pg-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('pg-1');
+});
+
+it('creates a person group via POST', function () {
+    Http::fake(['*api/persongroups*' => Http::response(['id' => 'new-pg', 'groupName' => 'Marketing'])]);
+
+    $result = TOPDesk::createPersonGroup(['groupName' => 'Marketing']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('new-pg');
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_contains($r->url(), 'api/persongroups'));
+});
+
+it('returns members of a person group as a Collection', function () {
+    Http::fake(['*api/persongroups/pg-1/persons*' => Http::response([['id' => 'person-1']])]);
+
+    $result = TOPDesk::getPersonGroupPersons('pg-1');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+});
+
+it('returns groups that a person belongs to as a Collection', function () {
+    Http::fake(['*api/persons/person-uuid/persongroups*' => Http::response([['id' => 'pg-1']])]);
+
+    $result = TOPDesk::getPersonGroupsForPerson('person-uuid');
+
+    expect($result)->toBeInstanceOf(Collection::class);
+});

--- a/tests/Feature/PersonsTest.php
+++ b/tests/Feature/PersonsTest.php
@@ -132,3 +132,59 @@ it('returns groups that a person belongs to as a Collection', function () {
 
     expect($result)->toBeInstanceOf(Collection::class);
 });
+
+it('returns person lookup results as a Collection', function () {
+    Http::fake(['*api/persons/lookup*' => Http::response([
+        ['id' => 'person-1', 'surName' => 'Smith'],
+        ['id' => 'person-2', 'surName' => 'Jones'],
+    ])]);
+
+    $result = TOPDesk::getPersonLookup(['name' => 'Smith']);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persons/lookup'));
+});
+
+it('updates a person group via PATCH to api/persongroups/{id}', function () {
+    Http::fake(['*api/persongroups/pg-1*' => Http::response(['id' => 'pg-1', 'groupName' => 'Updated Group'])]);
+
+    $result = TOPDesk::updatePersonGroup('pg-1', ['groupName' => 'Updated Group']);
+
+    expect($result)->toBeObject()->and($result->id)->toBe('pg-1');
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH'
+        && str_contains($r->url(), 'api/persongroups/pg-1')
+    );
+});
+
+it('archives a person group via POST to api/persongroups/{id}/archive', function () {
+    Http::fake(['*api/persongroups/pg-1/archive*' => Http::response('', 204)]);
+
+    $result = TOPDesk::archivePersonGroup('pg-1');
+
+    expect($result)->toBe([]);
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), 'api/persongroups/pg-1/archive')
+    );
+});
+
+it('unarchives a person group via POST to api/persongroups/id/{id}/unarchive', function () {
+    Http::fake(['*api/persongroups/id/pg-1/unarchive*' => Http::response(['id' => 'pg-1'])]);
+
+    $result = TOPDesk::unarchivePersonGroup('pg-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('pg-1');
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), 'api/persongroups/id/pg-1/unarchive')
+    );
+});
+
+it('returns person group lookup results as a Collection', function () {
+    Http::fake(['*api/persongroups/lookup*' => Http::response([
+        ['id' => 'pg-1', 'name' => 'Finance'],
+    ])]);
+
+    $result = TOPDesk::getPersonGroupLookup(['name' => 'Finance']);
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persongroups/lookup'));
+});

--- a/tests/Feature/PersonsTest.php
+++ b/tests/Feature/PersonsTest.php
@@ -49,8 +49,7 @@ it('updates a person via PATCH to api/persons/{id}', function () {
 
     TOPDesk::updatePerson('person-uuid', ['phoneNumber' => '+44 1234 567890']);
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/persons/person-uuid')
     );
 });
@@ -60,8 +59,7 @@ it('archives a person via PATCH to api/persons/id/{id}/archive', function () {
 
     TOPDesk::archivePerson('person-uuid');
 
-    Http::assertSent(fn ($r) =>
-        $r->method() === 'PATCH' &&
+    Http::assertSent(fn ($r) => $r->method() === 'PATCH' &&
         str_contains($r->url(), 'api/persons/id/person-uuid/archive')
     );
 });

--- a/tests/Feature/SuppliersTest.php
+++ b/tests/Feature/SuppliersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Facades\TOPDesk;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+// getSuppliers and getSupplier are already tested in GeneralTest.php.
+// This file covers the remaining Supplier operations.
+
+it('returns supplier lookup results as a cached Collection', function () {
+    Http::fake(['*api/suppliers/lookup*' => Http::response([
+        ['id' => 'sup-1', 'name' => 'Dell'],
+        ['id' => 'sup-2', 'name' => 'HP'],
+    ])]);
+
+    $first = TOPDesk::getSupplierLookup();
+    $second = TOPDesk::getSupplierLookup();
+
+    expect($first)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSentCount(1); // cached after first call
+});
+
+it('passes options to the supplier lookup endpoint', function () {
+    Http::fake(['*api/suppliers/lookup*' => Http::response([['id' => 'sup-1', 'name' => 'Dell']])]);
+
+    TOPDesk::getSupplierLookup(['name' => 'Dell']);
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/suppliers/lookup')
+        && str_contains($r->url(), 'name=Dell')
+    );
+});
+
+it('returns supplier contacts as a Collection', function () {
+    Http::fake(['*api/supplierContacts*' => Http::response([
+        ['id' => 'contact-1', 'surName' => 'Smith'],
+        ['id' => 'contact-2', 'surName' => 'Jones'],
+    ])]);
+
+    $result = TOPDesk::getSupplierContacts();
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/supplierContacts'));
+});
+
+it('fetches a single supplier contact by id', function () {
+    Http::fake(['*api/supplierContacts/*' => Http::response(['id' => 'contact-1', 'surName' => 'Smith'])]);
+
+    $result = TOPDesk::getSupplierContact('contact-1');
+
+    expect($result)->toBeObject()->and($result->id)->toBe('contact-1');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/supplierContacts/contact-1'));
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Tests\TestCase;
+
+uses(TestCase::class)->in('Feature', 'Unit');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,10 +25,10 @@ class TestCase extends Orchestra
     protected function defineEnvironment($app): void
     {
         $app['config']->set('topdesk', [
-            'endpoint'             => 'https://company.topdesk.net/tas/',
+            'endpoint' => 'https://company.topdesk.net/tas/',
             'application_username' => 'test@example.com',
             'application_password' => 'test-password',
-            'ignore_cache'         => false,
+            'ignore_cache' => false,
         ]);
 
         // Use the array driver so cache is isolated per test.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FredBradley\TOPDesk\Tests;
+
+use FredBradley\TOPDesk\TOPDeskServiceProvider;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Throw if any test accidentally makes a real HTTP call without a fake.
+        Http::preventStrayRequests();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [TOPDeskServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('topdesk', [
+            'endpoint'             => 'https://company.topdesk.net/tas/',
+            'application_username' => 'test@example.com',
+            'application_password' => 'test-password',
+            'ignore_cache'         => false,
+        ]);
+
+        // Use the array driver so cache is isolated per test.
+        $app['config']->set('cache.default', 'array');
+    }
+}

--- a/tests/Unit/BaseModelTest.php
+++ b/tests/Unit/BaseModelTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Models\Asset;
+use FredBradley\TOPDesk\Models\BaseModel;
+use FredBradley\TOPDesk\Models\Branch;
+use FredBradley\TOPDesk\Models\Location;
+use FredBradley\TOPDesk\Models\Operator;
+use FredBradley\TOPDesk\Models\OperatorGroup;
+use FredBradley\TOPDesk\Models\Person;
+use FredBradley\TOPDesk\Models\PersonGroup;
+use FredBradley\TOPDesk\Models\Supplier;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+
+// BaseModel is abstract; we test through concrete subclasses (Branch, Asset, Operator).
+
+it('constructs a model instance from an array, assigning all properties', function () {
+    $branch = new Branch(['id' => 'br-uuid', 'name' => 'London HQ']);
+
+    expect($branch->id)->toBe('br-uuid');
+    expect($branch->name)->toBe('London HQ');
+});
+
+it('constructs a model instance from a stdClass, assigning all properties', function () {
+    $obj = (object) ['id' => 'br-uuid', 'name' => 'Manchester'];
+    $branch = new Branch($obj);
+
+    expect($branch->id)->toBe('br-uuid');
+    expect($branch->name)->toBe('Manchester');
+});
+
+it('find() delegates to findById() and returns the model', function () {
+    Http::fake(['*api/branches/id/*' => Http::response(['id' => 'br-uuid', 'name' => 'London HQ'])]);
+
+    $result = Branch::find('br-uuid');
+
+    expect($result)->toBeInstanceOf(Branch::class);
+    expect($result->id)->toBe('br-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches/id/br-uuid'));
+});
+
+it('findById() uses the /id/ path for models that require it (Branch)', function () {
+    Http::fake(['*api/branches/id/*' => Http::response(['id' => 'br-uuid', 'name' => 'Test Branch'])]);
+
+    $result = Branch::findById('br-uuid');
+
+    expect($result)->toBeInstanceOf(Branch::class)->and($result->id)->toBe('br-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches/id/br-uuid'));
+});
+
+it('findById() uses a direct path (no /id/) for Asset', function () {
+    Http::fake(['*api/assetmgmt/assets/asset-uuid*' => Http::response(['id' => 'asset-uuid', 'name' => 'LAPTOP-001'])]);
+
+    $result = Asset::findById('asset-uuid');
+
+    expect($result)->toBeInstanceOf(Asset::class)->and($result->id)->toBe('asset-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/assetmgmt/assets/asset-uuid')
+        && ! str_contains($r->url(), '/id/')
+    );
+});
+
+it('findById() uses the /id/ path for Operator', function () {
+    Http::fake(['*api/operators/id/*' => Http::response(['id' => 'op-uuid', 'surName' => 'Smith'])]);
+
+    $result = Operator::findById('op-uuid');
+
+    expect($result)->toBeInstanceOf(Operator::class)->and($result->id)->toBe('op-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operators/id/op-uuid'));
+});
+
+it('whereVariableEquals() queries the API and returns a Collection of model instances', function () {
+    Http::fake(['*api/branches/*' => Http::response([
+        ['id' => 'br-1', 'name' => 'London HQ'],
+        ['id' => 'br-2', 'name' => 'London South'],
+    ])]);
+
+    $result = Branch::whereVariableEquals('name', 'London HQ');
+
+    expect($result)->toBeInstanceOf(Collection::class)->toHaveCount(2);
+    expect($result->first())->toBeInstanceOf(Branch::class);
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/branches'));
+});
+
+it('whereVariableEquals() caches results and only calls the API once', function () {
+    Http::fake(['*api/branches/*' => Http::response([['id' => 'br-1', 'name' => 'London HQ']])]);
+
+    Branch::whereVariableEquals('name', 'London HQ');
+    Branch::whereVariableEquals('name', 'London HQ');
+
+    Http::assertSentCount(1);
+});
+
+it('whereVariableEquals() busts the cache when forgetCache is true', function () {
+    Http::fake(['*api/branches/*' => Http::response([['id' => 'br-1', 'name' => 'London HQ']])]);
+
+    Branch::whereVariableEquals('name', 'London HQ');
+    Branch::whereVariableEquals('name', 'London HQ', forgetCache: true);
+
+    Http::assertSentCount(2);
+});
+
+it('findFirstByVariable() returns the first matching model instance', function () {
+    Http::fake(['*api/branches/*' => Http::response([
+        ['id' => 'br-1', 'name' => 'London HQ'],
+        ['id' => 'br-2', 'name' => 'London City'],
+    ])]);
+
+    $result = Branch::findFirstByVariable('name', 'London HQ');
+
+    expect($result)->toBeInstanceOf(BaseModel::class);
+    expect($result->id)->toBe('br-1');
+});
+
+it('findById() resolves the correct endpoint for Location', function () {
+    Http::fake(['*api/locations/id/*' => Http::response(['id' => 'loc-uuid', 'name' => 'Server Room'])]);
+
+    $result = Location::findById('loc-uuid');
+
+    expect($result)->toBeInstanceOf(Location::class)->and($result->id)->toBe('loc-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/locations/id/loc-uuid'));
+});
+
+it('findById() resolves the correct endpoint for OperatorGroup', function () {
+    Http::fake(['*api/operatorgroups/id/*' => Http::response(['id' => 'grp-uuid', 'groupName' => 'I.T. Services'])]);
+
+    $result = OperatorGroup::findById('grp-uuid');
+
+    expect($result)->toBeInstanceOf(OperatorGroup::class)->and($result->id)->toBe('grp-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/operatorgroups/id/grp-uuid'));
+});
+
+it('findById() resolves the correct endpoint for Person', function () {
+    Http::fake(['*api/persons/id/*' => Http::response(['id' => 'person-uuid', 'surName' => 'Smith'])]);
+
+    $result = Person::findById('person-uuid');
+
+    expect($result)->toBeInstanceOf(Person::class)->and($result->id)->toBe('person-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persons/id/person-uuid'));
+});
+
+it('findById() resolves the correct direct path for PersonGroup (no /id/ prefix)', function () {
+    Http::fake(['*api/persongroups/pg-uuid*' => Http::response(['id' => 'pg-uuid', 'name' => 'Students'])]);
+
+    $result = PersonGroup::findById('pg-uuid');
+
+    expect($result)->toBeInstanceOf(PersonGroup::class)->and($result->id)->toBe('pg-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/persongroups/pg-uuid')
+        && ! str_contains($r->url(), '/id/')
+    );
+});
+
+it('findById() resolves the correct direct path for Supplier (no /id/ prefix)', function () {
+    Http::fake(['*api/suppliers/sup-uuid*' => Http::response(['id' => 'sup-uuid', 'name' => 'Dell'])]);
+
+    $result = Supplier::findById('sup-uuid');
+
+    expect($result)->toBeInstanceOf(Supplier::class)->and($result->id)->toBe('sup-uuid');
+    Http::assertSent(fn ($r) => str_contains($r->url(), 'api/suppliers/sup-uuid')
+        && ! str_contains($r->url(), '/id/')
+    );
+});

--- a/tests/Unit/ExceptionsTest.php
+++ b/tests/Unit/ExceptionsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use FredBradley\TOPDesk\Exceptions\ConfigNotFound;
+use FredBradley\TOPDesk\Exceptions\OperatorGroupNotFound;
+use FredBradley\TOPDesk\Exceptions\OperatorNotFound;
+use FredBradley\TOPDesk\Exceptions\PersonNotFound;
+
+// --- PersonNotFound ---
+
+it('PersonNotFound extends RuntimeException', function () {
+    expect(new PersonNotFound('jsmith'))->toBeInstanceOf(\RuntimeException::class);
+});
+
+it('PersonNotFound carries HTTP 404 as its code', function () {
+    $e = new PersonNotFound('jsmith');
+
+    expect($e->getCode())->toBe(404);
+});
+
+it('PersonNotFound message includes the identifier', function () {
+    $e = new PersonNotFound('jsmith');
+
+    expect($e->getMessage())->toContain('jsmith');
+});
+
+it('PersonNotFound can be caught as RuntimeException', function () {
+    $caught = false;
+
+    try {
+        throw new PersonNotFound('testuser');
+    } catch (\RuntimeException) {
+        $caught = true;
+    }
+
+    expect($caught)->toBeTrue();
+});
+
+// --- OperatorNotFound ---
+
+it('OperatorNotFound extends Exception', function () {
+    expect(new OperatorNotFound())->toBeInstanceOf(\Exception::class);
+});
+
+it('OperatorNotFound accepts a custom message', function () {
+    $e = new OperatorNotFound('Operator jsmith not found');
+
+    expect($e->getMessage())->toBe('Operator jsmith not found');
+});
+
+// --- OperatorGroupNotFound ---
+
+it('OperatorGroupNotFound extends Exception', function () {
+    expect(new OperatorGroupNotFound())->toBeInstanceOf(\Exception::class);
+});
+
+it('OperatorGroupNotFound accepts a custom message', function () {
+    $e = new OperatorGroupNotFound('Group I.T. Services not found');
+
+    expect($e->getMessage())->toBe('Group I.T. Services not found');
+});
+
+// --- ConfigNotFound ---
+
+it('ConfigNotFound extends RuntimeException', function () {
+    expect(new ConfigNotFound())->toBeInstanceOf(\RuntimeException::class);
+});
+
+it('ConfigNotFound can be thrown and caught', function () {
+    $caught = false;
+
+    try {
+        throw new ConfigNotFound("Config value 'topdesk.endpoint' is not set.");
+    } catch (ConfigNotFound $e) {
+        $caught = true;
+        expect($e->getMessage())->toContain('topdesk.endpoint');
+    }
+
+    expect($caught)->toBeTrue();
+});

--- a/tests/Unit/ExceptionsTest.php
+++ b/tests/Unit/ExceptionsTest.php
@@ -10,7 +10,7 @@ use FredBradley\TOPDesk\Exceptions\PersonNotFound;
 // --- PersonNotFound ---
 
 it('PersonNotFound extends RuntimeException', function () {
-    expect(new PersonNotFound('jsmith'))->toBeInstanceOf(\RuntimeException::class);
+    expect(new PersonNotFound('jsmith'))->toBeInstanceOf(RuntimeException::class);
 });
 
 it('PersonNotFound carries HTTP 404 as its code', function () {
@@ -30,7 +30,7 @@ it('PersonNotFound can be caught as RuntimeException', function () {
 
     try {
         throw new PersonNotFound('testuser');
-    } catch (\RuntimeException) {
+    } catch (RuntimeException) {
         $caught = true;
     }
 
@@ -40,7 +40,7 @@ it('PersonNotFound can be caught as RuntimeException', function () {
 // --- OperatorNotFound ---
 
 it('OperatorNotFound extends Exception', function () {
-    expect(new OperatorNotFound())->toBeInstanceOf(\Exception::class);
+    expect(new OperatorNotFound)->toBeInstanceOf(Exception::class);
 });
 
 it('OperatorNotFound accepts a custom message', function () {
@@ -52,7 +52,7 @@ it('OperatorNotFound accepts a custom message', function () {
 // --- OperatorGroupNotFound ---
 
 it('OperatorGroupNotFound extends Exception', function () {
-    expect(new OperatorGroupNotFound())->toBeInstanceOf(\Exception::class);
+    expect(new OperatorGroupNotFound)->toBeInstanceOf(Exception::class);
 });
 
 it('OperatorGroupNotFound accepts a custom message', function () {
@@ -64,7 +64,7 @@ it('OperatorGroupNotFound accepts a custom message', function () {
 // --- ConfigNotFound ---
 
 it('ConfigNotFound extends RuntimeException', function () {
-    expect(new ConfigNotFound())->toBeInstanceOf(\RuntimeException::class);
+    expect(new ConfigNotFound)->toBeInstanceOf(RuntimeException::class);
 });
 
 it('ConfigNotFound can be thrown and caught', function () {


### PR DESCRIPTION
- Raise minimum requirements to PHP ^8.2 and add Laravel 13 support
- Replace fredbradley/cacher with Laravel's built-in Cache facade throughout
- Migrate test suite from PHPUnit to Pest v3 with Feature/Unit split
- Add nine new domain traits: Branches, Departments, General, IncidentActions, IncidentLookups, Locations, OperatorManagement, PersonManagement, Suppliers
- Add Branch, Location, Supplier models with BaseModel endpoint resolution
- Add PersonNotFound domain exception; type-safe strict_types=1 on all files
- Unified HTTP layer: remove Guzzle client, everything flows through Http::topdeskAuth()
- Return Collection instead of plain arrays from API list methods
- Expand Facade @method stubs to document the full public surface
- Add CLAUDE.md codebase guide and docs/ API reference