### PR TITLE
fix: cache raw stdClass instead of model objects to prevent __PHP_Incomplete_Class

### DIFF
--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -64,12 +64,10 @@ abstract class BaseModel
             forgetCache: $forgetCache);
 
         return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($variableValue, $variableKey) {
-            $result = TOPDesk::query()->get('api/'.self::$endpoint.'/', [
+            return TOPDesk::query()->get('api/'.self::$endpoint.'/', [
                 'query' => $variableKey.'=='.$variableValue,
-            ])->throw()->collect()->mapInto(self::$model);
-
-            return $result;
-        });
+            ])->throw()->collect();
+        })->mapInto(self::$model);
     }
 
     public static function findById(string $id, bool $forgetCache = false): BaseModel
@@ -78,16 +76,16 @@ abstract class BaseModel
 
         $cacheKey = TOPDesk::setupCacheObject(cacheKey: Str::slug(self::$endpoint.'id'.$id), forgetCache: $forgetCache);
 
-        return self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
+        $data = self::cache()->remember($cacheKey, EasySeconds::minutes(5), function () use ($id) {
             // Some APIs use /{id} directly; others use /id/{id}
             $noIdPrefix = [Asset::class, PersonGroup::class, Supplier::class];
             $endpoint = in_array(self::$model, $noIdPrefix)
                 ? 'api/'.self::$endpoint.'/'.$id
                 : 'api/'.self::$endpoint.'/id/'.$id;
 
-            $result = TOPDesk::query()->get($endpoint)->throw()->object();
-
-            return new self::$model($result);
+            return TOPDesk::query()->get($endpoint)->throw()->object();
         });
+
+        return new self::$model($data);
     }
 }


### PR DESCRIPTION
## Problem

When Laravel's `serializable_classes` config restricts which PHP classes can be unserialized from cache (e.g. `[Collection::class, stdClass::class]`), caching a `BaseModel` subclass instance causes it to be returned as `__PHP_Incomplete_Class` on subsequent cache hits.

With `declare(strict_types=1)` and a declared return type of `BaseModel`, PHP then raises:

```
TypeError: FredBradley\TOPDesk\Models\BaseModel::findById(): Return value must be of type
FredBradley\TOPDesk\Models\BaseModel, __PHP_Incomplete_Class returned
```

This happens on the **second** call — the first call populates the cache correctly, but the second retrieval fails because the class can't be deserialized.

## Root cause

Both `findById()` and `whereVariableEquals()` were caching fully-constructed PHP model objects. Only `stdClass` and `Collection` are safe to serialize/unserialize across all cache drivers and `serializable_classes` configurations.

## Fix

- **`findById()`**: cache the raw `stdClass` response from the API (safe), then construct the model object *after* the cache returns.
- **`whereVariableEquals()`**: cache the plain `Collection` of `stdClass` items, then call `->mapInto()` *outside* the `remember()` callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)